### PR TITLE
Implement garbage collection

### DIFF
--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -28,7 +28,7 @@ type KustomizationSpec struct {
 	// +required
 	Path string `json:"path"`
 
-	// Label selector used for prune operations, e.g. env=staging.
+	// Label selector used for garbage collection.
 	// +kubebuilder:validation:Pattern="^.*=.*$"
 	// +optional
 	Prune string `json:"prune,omitempty"`

--- a/config/crd/bases/kustomize.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.fluxcd.io_kustomizations.yaml
@@ -54,7 +54,7 @@ spec:
               pattern: ^\./
               type: string
             prune:
-              description: Label selector used for prune operations, e.g. env=staging.
+              description: Label selector used for garbage collection.
               pattern: ^.*=.*$
               type: string
             sourceRef:

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -83,7 +83,7 @@ func (r *KustomizationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	// try git sync
 	syncedKustomization, err := r.sync(ctx, *kustomization.DeepCopy(), source)
 	if err != nil {
-		log.Error(err, "Kustomization sync failed")
+		log.Error(err, "Kustomization apply failed")
 	}
 
 	// update status
@@ -101,6 +101,7 @@ func (r *KustomizationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 func (r *KustomizationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kustomizev1.Kustomization{}).
+		WithEventFilter(KustomizationGarbageCollectPredicate{Log: r.Log}).
 		WithEventFilter(KustomizationSyncAtPredicate{}).
 		Complete(r)
 }


### PR DESCRIPTION
Changes:
- add `GarbageCollect` predicate to `KustomizationReconciler`
- remove the Kubernetes objects previously applied on the cluster, based on `spec.prune` label select
- add garbage collection spec to docs