### PR TITLE
Record last applied revision

### DIFF
--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -96,9 +96,14 @@ type WorkloadReference struct {
 type KustomizationStatus struct {
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
+
+	// The last successfully applied revision.
+	// The revision format for Git sources is <branch|tag>/<commit-sha>.
+	// +optional
+	LastAppliedRevision string `json:"lastAppliedRevision,omitempty"`
 }
 
-func KustomizationReady(kustomization Kustomization, reason, message string) Kustomization {
+func KustomizationReady(kustomization Kustomization, revision, reason, message string) Kustomization {
 	kustomization.Status.Conditions = []Condition{
 		{
 			Type:               ReadyCondition,
@@ -108,6 +113,7 @@ func KustomizationReady(kustomization Kustomization, reason, message string) Kus
 			Message:            message,
 		},
 	}
+	kustomization.Status.LastAppliedRevision = revision
 	return kustomization
 }
 

--- a/config/crd/bases/kustomize.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.fluxcd.io_kustomizations.yaml
@@ -166,6 +166,10 @@ spec:
                 - type
                 type: object
               type: array
+            lastAppliedRevision:
+              description: The last successfully applied revision. The revision format
+                for Git sources is <branch|tag>/<commit-sha>.
+              type: string
           type: object
       type: object
   version: v1alpha1

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -253,6 +253,7 @@ func (r *KustomizationReconciler) sync(
 
 	return kustomizev1.KustomizationReady(
 		kustomization,
+		source.GetArtifact().Revision,
 		kustomizev1.ApplySucceedReason,
 		"kustomization was successfully applied",
 	), nil

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -39,15 +39,13 @@ that describes a pipeline such as:
 - **alert** if something went wrong
 - **notify** if the cluster state changed 
 
-![pipeline](../diagrams/kustomize-controller-pipeline.png)
-
-The controller the runs these pipelines relies on
+The controller that runs these pipelines relies on
 [source-controller](https://github.com/fluxcd/source-controller)
 for providing the raw manifests from Git repositories or any
-other sources that source-controller could support in the future. 
+other source that source-controller could support in the future. 
 
-If a Git repository contains no Kustomize manifests, the controller will
-generate the `kustomization.yaml` automatically and label
+If a Git repository contains no Kustomize manifests, the controller can
+generate the `kustomization.yaml` file automatically and label
 the objects for garbage collection (GC).
 
 A pipeline runs on-a-schedule and ca be triggered manually by a
@@ -56,8 +54,8 @@ cluster admin or automatically by a source event such as a Git revision change.
 When a pipeline is removed from the cluster, the controller's GC terminates
 all the objects previously created by that pipeline.
 
-A pipeline can be suspended, while in suspension the controller will
-stop the scheduler and will ignore any source events.
+A pipeline can be suspended, while in suspension the controller
+stops the scheduler and ignores any source events.
 Deleting a suspended pipeline does not trigger garbage collection.
 
 Alerting can be configured with a Kubernetes custom resource

--- a/docs/spec/v1alpha1/README.md
+++ b/docs/spec/v1alpha1/README.md
@@ -12,6 +12,7 @@ of Kubernetes objects generated with Kustomize.
     + [Garbage collection](kustomization.md#garbage-collection)
     + [Health assessment](kustomization.md#health-assessment)
     + [Kustomization dependencies](kustomization.md#kustomization-dependencies)
+    + [Status](kustomization.md#status)
 - [Profile CRD](profile.md)
     + [Alerting configuration](profile.md#alerting)
 


### PR DESCRIPTION
- add `LastAppliedRevision` field to Status sub-resource
- set `status.LastAppliedRevision` after a successful sync
- add Status section to spec docs