### PR TITLE
Report progressing status

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -75,6 +75,10 @@ const (
 	// InitializedReason represents the fact that a given resource has been initialized.
 	InitializedReason string = "Initialized"
 
+	// ProgressingReason represents the fact that a kustomization reconciliation
+	// is underway.
+	ProgressingReason string = "Progressing"
+
 	// SuspendedReason represents the fact that the kustomization execution is suspended.
 	SuspendedReason string = "Suspended"
 

--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -117,6 +117,19 @@ func KustomizationReady(kustomization Kustomization, revision, reason, message s
 	return kustomization
 }
 
+func KustomizationProgressing(kustomization Kustomization) Kustomization {
+	kustomization.Status.Conditions = []Condition{
+		{
+			Type:               ReadyCondition,
+			Status:             corev1.ConditionUnknown,
+			LastTransitionTime: metav1.Now(),
+			Reason:             ProgressingReason,
+			Message:            "reconciliation in progress",
+		},
+	}
+	return kustomization
+}
+
 func KustomizationNotReady(kustomization Kustomization, reason, message string) Kustomization {
 	kustomization.Status.Conditions = []Condition{
 		{


### PR DESCRIPTION
Set ready condition to unknown while the reconciliation is progressing.
This allows other operators to wait for a sync to complete e.g:

```
kubectl annotate --overwrite kustomization/podinfo kustomize.fluxcd.io/syncAt="$(date +%s)" && \
kubectl wait kustomization/podinfo --for=condition=ready --timeout=1m
```