### PR TITLE
Watch resources in the runtime namespace only

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         ports:
           - containerPort: 8282
             name: http-prom
+        env:
+          - name: RUNTIME_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             port: http-prom

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -159,12 +159,16 @@ func (r *KustomizationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	return ctrl.Result{RequeueAfter: kustomization.Spec.Interval.Duration}, nil
 }
 
-func (r *KustomizationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+type KustomizationReconcilerOptions struct {
+	MaxConcurrentReconciles int
+}
+
+func (r *KustomizationReconciler) SetupWithManager(mgr ctrl.Manager, opts KustomizationReconcilerOptions) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kustomizev1.Kustomization{}).
 		WithEventFilter(KustomizationGarbageCollectPredicate{Log: r.Log}).
 		WithEventFilter(KustomizationSyncAtPredicate{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 4}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: opts.MaxConcurrentReconciles}).
 		Complete(r)
 }
 


### PR DESCRIPTION
Make the controller watch for resources only in namespace where it has been deployed. 