### PR TITLE
Update kubectl to v1.18.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ kustomize_url=https://github.com/kubernetes-sigs/kustomize/releases/download && 
 curl -sL ${kustomize_url}/kustomize%2Fv${kustomize_ver}/kustomize_v${kustomize_ver}_linux_amd64.tar.gz | \
 tar xz && mv kustomize /usr/local/bin/kustomize
 
-RUN kubectl_ver=1.18.6 && \
+RUN kubectl_ver=1.18.8 && \
 curl -sL https://storage.googleapis.com/kubernetes-release/release/v${kubectl_ver}/bin/linux/amd64/kubectl \
 -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
Fixes JSON patch exponential time complexity for nesting depth of manifest https://github.com/kubernetes/kubernetes/issues/91615