### PR TITLE
api: rename Unsortable to CircularDependencyError

### DIFF
--- a/api/v1alpha1/sort.go
+++ b/api/v1alpha1/sort.go
@@ -20,13 +20,17 @@ import (
 	"fmt"
 )
 
+// CircularDependencyError contains the circular dependency chains
+// that were detected while sorting 'HelmReleaseSpec.DependsOn'.
 // +kubebuilder:object:generate=false
-type Unsortable [][]string
+type CircularDependencyError [][]string
 
-func (e Unsortable) Error() string {
+func (e CircularDependencyError) Error() string {
 	return fmt.Sprintf("circular dependencies: %v", [][]string(e))
 }
 
+// DependencySort sorts the Kustomization slice based on their listed
+// dependencies using Tarjan's strongly connected components algorithm.
 func DependencySort(ks []Kustomization) ([]Kustomization, error) {
 	n := make(graph)
 	lookup := map[string]*Kustomization{}
@@ -36,7 +40,7 @@ func DependencySort(ks []Kustomization) ([]Kustomization, error) {
 	}
 	sccs := tarjanSCC(n)
 	var sorted []Kustomization
-	var unsortable Unsortable
+	var unsortable CircularDependencyError
 	for i := 0; i < len(sccs); i++ {
 		s := sccs[i]
 		if len(s) != 1 {

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -218,6 +218,10 @@ KustomizationStatus
 </table>
 </div>
 </div>
+<h3 id="kustomize.toolkit.fluxcd.io/v1alpha1.CircularDependencyError">CircularDependencyError
+(<code>[][]string</code> alias)</h3>
+<p>CircularDependencyError contains the circular dependency chains
+that were detected while sorting &lsquo;HelmReleaseSpec.DependsOn&rsquo;.</p>
 <h3 id="kustomize.toolkit.fluxcd.io/v1alpha1.Condition">Condition
 </h3>
 <p>
@@ -741,8 +745,6 @@ map[string]string
 </table>
 </div>
 </div>
-<h3 id="kustomize.toolkit.fluxcd.io/v1alpha1.Unsortable">Unsortable
-(<code>[][]string</code> alias)</h3>
 <h3 id="kustomize.toolkit.fluxcd.io/v1alpha1.WorkloadReference">WorkloadReference
 </h3>
 <p>


### PR DESCRIPTION
As this better reflects the error's contents.

Aligns with changes made in https://github.com/fluxcd/helm-controller/pull/58.