### PR TITLE
Configure manager logging and set level to info

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             path: /metrics
         args:
         - --enable-leader-election
-        - --log-level=debug
+        - --log-level=info
         - --log-json
         resources:
           limits:

--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "7593cc5d.fluxcd.io",
 		Namespace:          os.Getenv("RUNTIME_NAMESPACE"),
+		Logger:             ctrl.Log,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This change should be mode for all controllers as the debug level is too verbose when issuing Kubernetes events. 