### PR TITLE
Refactor garbage collector

### DIFF
--- a/controllers/kustomization_gc.go
+++ b/controllers/kustomization_gc.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"os/exec"
-	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 
@@ -16,89 +19,99 @@ import (
 type KustomizeGarbageCollector struct {
 	snapshot kustomizev1.Snapshot
 	log      logr.Logger
+	client.Client
 }
 
-func NewGarbageCollector(snapshot kustomizev1.Snapshot, log logr.Logger) *KustomizeGarbageCollector {
+func NewGarbageCollector(kubeClient client.Client, snapshot kustomizev1.Snapshot, log logr.Logger) *KustomizeGarbageCollector {
 	return &KustomizeGarbageCollector{
+		Client:   kubeClient,
 		snapshot: snapshot,
 		log:      log,
 	}
 }
 
+// Prune deletes Kubernetes objects removed from source.
+// Namespaced objects are removed before global ones, as in CRs before CRDs.
+// The garbage collector determines what objects to prune based on
+// a label selector that contains the previously applied revision.
+// The garbage collector ignores objects that are no longer present
+// on the cluster or if they are marked for deleting using Kubernetes finalizers.
 func (kgc *KustomizeGarbageCollector) Prune(timeout time.Duration, name string, namespace string) (string, bool) {
-	selector := kgc.selectors(name, namespace, kgc.snapshot.Revision)
-	ok := true
 	changeSet := ""
-	outInfo := ""
 	outErr := ""
-	for ns, kinds := range kgc.snapshot.NamespacedKinds() {
-		for _, kind := range kinds {
-			if output, err := kgc.deleteByKind(timeout, kind, ns, selector); err != nil {
-				outErr += " " + err.Error()
-				ok = false
-			} else {
-				outInfo += " " + output + "\n"
-			}
-		}
-	}
-	if outErr == "" {
-		kgc.log.Info("Garbage collection for namespaced objects completed",
-			"kustomization", fmt.Sprintf("%s/%s", namespace, name),
-			"output", outInfo)
-		changeSet += outInfo
-	} else {
 
-		kgc.log.Error(fmt.Errorf(outErr), "Garbage collection for namespaced objects failed",
-			"kustomization", fmt.Sprintf("%s/%s", namespace, name))
-	}
-
-	outInfo = ""
-	outErr = ""
-	for _, kind := range kgc.snapshot.NonNamespacedKinds() {
-		if output, err := kgc.deleteByKind(timeout, kind, "", selector); err != nil {
-			outErr += " " + err.Error()
-			ok = false
-		} else {
-			outInfo += " " + output + "\n"
-		}
-	}
-	if outErr == "" {
-		kgc.log.Info("Garbage collection for non-namespaced objects completed",
-			"kustomization", fmt.Sprintf("%s/%s", namespace, name),
-			"output", outInfo)
-		changeSet += outInfo
-	} else {
-		kgc.log.Error(fmt.Errorf(outErr), "Garbage collection for non-namespaced objects failed",
-			"kustomization", fmt.Sprintf("%s/%s", namespace, name))
-	}
-
-	return changeSet, ok
-}
-
-func (kgc *KustomizeGarbageCollector) deleteByKind(timeout time.Duration, kind, namespace, selector string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+time.Second)
 	defer cancel()
 
-	cmd := fmt.Sprintf("kubectl delete %s -l %s", kind, selector)
-	if namespace != "" {
-		cmd = fmt.Sprintf("%s -n=%s", cmd, namespace)
+	for ns, gvks := range kgc.snapshot.NamespacedKinds() {
+		for _, gvk := range gvks {
+			ulist := &unstructured.UnstructuredList{}
+			ulist.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   gvk.Group,
+				Kind:    gvk.Kind + "List",
+				Version: gvk.Version,
+			})
+
+			err := kgc.List(ctx, ulist, client.InNamespace(ns), kgc.matchingLabels(name, namespace, kgc.snapshot.Revision))
+			if err == nil {
+				for _, item := range ulist.Items {
+					if item.GetDeletionTimestamp().IsZero() {
+						name := fmt.Sprintf("%s/%s/%s", item.GetKind(), item.GetNamespace(), item.GetName())
+						err = kgc.Delete(ctx, &item)
+						if err != nil {
+							outErr += fmt.Sprintf("delete failed for %s: %v\n", name, err)
+						} else {
+							if len(item.GetFinalizers()) > 0 {
+								changeSet += fmt.Sprintf("%s/%s marked for deletion\n", item.GetNamespace(), item.GetName())
+							} else {
+								changeSet += fmt.Sprintf("%s/%s deleted\n", item.GetNamespace(), item.GetName())
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
-	command := exec.CommandContext(ctx, "/bin/sh", "-c", cmd)
-	if output, err := command.CombinedOutput(); err != nil {
-		// ignore unknown resource kind
-		if strings.Contains(string(output), "the server doesn't have a resource type") {
-			return strings.TrimSuffix(string(output), "\n"), nil
-		} else {
-			return "", fmt.Errorf("%s", strings.TrimSuffix(string(output), "\n"))
+	for _, gvk := range kgc.snapshot.NonNamespacedKinds() {
+		ulist := &unstructured.UnstructuredList{}
+		ulist.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Kind:    gvk.Kind + "List",
+			Version: gvk.Version,
+		})
+
+		err := kgc.List(ctx, ulist, kgc.matchingLabels(name, namespace, kgc.snapshot.Revision))
+		if err == nil {
+			for _, item := range ulist.Items {
+				if item.GetDeletionTimestamp().IsZero() {
+					name := fmt.Sprintf("%s/%s", item.GetKind(), item.GetName())
+					err = kgc.Delete(ctx, &item)
+					if err != nil {
+						outErr += fmt.Sprintf("delete failed for %s: %v\n", name, err)
+					} else {
+						if len(item.GetFinalizers()) > 0 {
+							changeSet += fmt.Sprintf("%s/%s marked for deletion\n", item.GetKind(), item.GetName())
+						} else {
+							changeSet += fmt.Sprintf("%s/%s deleted\n", item.GetKind(), item.GetName())
+						}
+					}
+				}
+			}
 		}
-	} else {
-		return strings.TrimSuffix(string(output), "\n"), nil
 	}
+
+	if outErr != "" {
+		return outErr, false
+	}
+	return changeSet, true
 }
 
-func (kgc *KustomizeGarbageCollector) selectors(name, namespace, revision string) string {
-	return fmt.Sprintf("kustomization/name=%s-%s,kustomization/revision=%s", name, namespace, checksum(revision))
+func (kgc *KustomizeGarbageCollector) matchingLabels(name, namespace, revision string) client.MatchingLabels {
+	return client.MatchingLabels{
+		"kustomization/name":     fmt.Sprintf("%s-%s", name, namespace),
+		"kustomization/revision": checksum(revision),
+	}
 }
 
 func gcLabels(name, namespace, revision string) map[string]string {


### PR DESCRIPTION
Changes:
- rewrite GC with controller-runtime client instead of kubectl shell-outs
- track group version kinds instead of kinds (GC snapshot API breaking change)
- ignore objects that are no longer present on the cluster
- delete namespaced CRs before CRDs
- mark for deletion objects with finalizers
- ignore objects stuck in finalization

Fix: #98 
