### PR TITLE
Use manifests checksum in GC snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run ./main.go --metrics-addr=:8089
 
 # Download the CRDs the controller depends on
 download-crd-deps:

--- a/api/v1alpha1/snapshot_types.go
+++ b/api/v1alpha1/snapshot_types.go
@@ -30,9 +30,9 @@ import (
 // Snapshot holds the metadata of the Kubernetes objects
 // generated for a source revision
 type Snapshot struct {
-	// The source revision.
+	// The manifests sha1 checksum.
 	// +required
-	Revision string `json:"revision"`
+	Checksum string `json:"checksum"`
 
 	// A list of Kubernetes kinds grouped by namespace.
 	// +required
@@ -51,9 +51,9 @@ type SnapshotEntry struct {
 	Kinds map[string]string `json:"kinds"`
 }
 
-func NewSnapshot(manifests []byte, revision string) (*Snapshot, error) {
+func NewSnapshot(manifests []byte, checksum string) (*Snapshot, error) {
 	snapshot := Snapshot{
-		Revision: revision,
+		Checksum: checksum,
 		Entries:  []SnapshotEntry{},
 	}
 

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -228,6 +228,9 @@ spec:
               snapshot:
                 description: The last successfully applied revision metadata.
                 properties:
+                  checksum:
+                    description: The manifests sha1 checksum.
+                    type: string
                   entries:
                     description: A list of Kubernetes kinds grouped by namespace.
                     items:
@@ -246,12 +249,9 @@ spec:
                       - kinds
                       type: object
                     type: array
-                  revision:
-                    description: The source revision.
-                    type: string
                 required:
+                - checksum
                 - entries
-                - revision
                 type: object
             type: object
         type: object

--- a/controllers/kustomization_gc.go
+++ b/controllers/kustomization_gc.go
@@ -107,15 +107,13 @@ func (kgc *KustomizeGarbageCollector) Prune(timeout time.Duration, name string, 
 }
 
 func (kgc *KustomizeGarbageCollector) matchingLabels(name, namespace, checksum string) client.MatchingLabels {
-	return client.MatchingLabels{
-		fmt.Sprintf("%s/name", kustomizev1.GroupVersion.Group):     fmt.Sprintf("%s-%s", name, namespace),
-		fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group): checksum,
-	}
+	return gcLabels(name, namespace, checksum)
 }
 
 func gcLabels(name, namespace, checksum string) map[string]string {
 	return map[string]string{
-		fmt.Sprintf("%s/name", kustomizev1.GroupVersion.Group):     fmt.Sprintf("%s-%s", name, namespace),
-		fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group): checksum,
+		fmt.Sprintf("%s/name", kustomizev1.GroupVersion.Group):      name,
+		fmt.Sprintf("%s/namespace", kustomizev1.GroupVersion.Group): namespace,
+		fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group):  checksum,
 	}
 }

--- a/controllers/kustomization_gc.go
+++ b/controllers/kustomization_gc.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/go-logr/logr"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1alpha1"
 )
@@ -61,9 +59,9 @@ func (kgc *KustomizeGarbageCollector) Prune(timeout time.Duration, name string, 
 							outErr += fmt.Sprintf("delete failed for %s: %v\n", name, err)
 						} else {
 							if len(item.GetFinalizers()) > 0 {
-								changeSet += fmt.Sprintf("%s/%s marked for deletion\n", item.GetNamespace(), item.GetName())
+								changeSet += fmt.Sprintf("%s marked for deletion\n", name)
 							} else {
-								changeSet += fmt.Sprintf("%s/%s deleted\n", item.GetNamespace(), item.GetName())
+								changeSet += fmt.Sprintf("%s deleted\n", name)
 							}
 						}
 					}

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -8,11 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sigs.k8s.io/kustomize/api/krusty"
-
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/krusty"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -816,13 +816,13 @@ generated for a source revision</p>
 <tbody>
 <tr>
 <td>
-<code>revision</code><br>
+<code>checksum</code><br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>The source revision.</p>
+<p>The manifests sha1 checksum.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR changes the way GC tracks changes, instead of labeling the Kubernetes objects with the source revision, we calculate the checksum of the manifests included in a kustomization and we use the checksum to label the applied objects. 

The GC labels have changed to:

```
kind: Namespace
metadata:
  labels:
    kustomize.toolkit.fluxcd.io/checksum: b3bd93b79387fa664600bdc82c6a8ee54932a95c
    kustomize.toolkit.fluxcd.io/name: test
    kustomize.toolkit.fluxcd.io/namespace: gitops-system
  name: dev
```

The name and namespace labels can be used to list all objects belonging to a kustomization:

```
$ kubectl get deployments \
-l=kustomize.toolkit.fluxcd.io/name=test,kustomize.toolkit.fluxcd.io/namespace=gitops-system \
--all-namespaces 

NAMESPACE   NAME       READY   UP-TO-DATE   AVAILABLE   AGE
dev         podinfo    2/2     2            2           3m48s
dev         podinfo2   1/1     1            1           55m
dev         podinfo3   1/1     1            1           55m
```

Fix: #88
Ref: https://github.com/fluxcd/toolkit/issues/238