### PR TITLE
Normalize the ready condition reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features:
 * watches `Source` objects for revision changes 
 * generates the `kustomization.yaml` file if needed
 * generates Kubernetes manifests with kustomize build
+* decrypts Kubernetes secrets with Mozilla SOPS
 * validates the build output with client-side or APIServer dry-run
 * applies the generated manifests on the cluster
 * prunes the Kubernetes objects removed from source
@@ -139,7 +140,7 @@ kubectl -n gitops-system logs deploy/kustomize-controller | jq .
 ```json
 {
   "level": "info",
-  "ts": 1587195448.071468,
+  "ts": "2020-09-17T07:27:11.921Z",
   "logger": "controllers.Kustomization",
   "msg": "Kustomization applied in 1.436096591s",
   "kustomization": "gitops-system/podinfo-dev",
@@ -170,9 +171,9 @@ If the kustomization reconciliation fails, the controller sets the ready conditi
 ```yaml
 status:
   conditions:
-  - lastTransitionTime: "2020-04-16T07:27:58Z"
-    message: 'apply failed'
-    reason: ApplyFailed
+  - lastTransitionTime: "2020-09-17T07:27:58Z"
+    message: 'namespaces dev not found'
+    reason: ReconciliationFailed
     status: "False"
     type: Ready
 ``` 

--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -48,43 +48,49 @@ type Condition struct {
 }
 
 const (
-	// ReadyCondition represents the fact that a given kustomization has passed
-	// validation and was successfully applied on the cluster.
+	// ReadyCondition is the name of the condition that
+	// records the readiness status of a Kustomization.
 	ReadyCondition string = "Ready"
 )
 
 const (
-	// ApplySucceededReason represents the fact that the kustomization apply succeeded.
-	ApplySucceededReason string = "ApplySucceeded"
+	// ReconciliationSucceededReason represents the fact that the
+	// reconciliation of the Kustomization has succeeded.
+	ReconciliationSucceededReason string = "ReconciliationSucceeded"
 
-	// ApplyFailedReason represents the fact that the kustomization apply failed.
-	ApplyFailedReason string = "ApplyFailed"
+	// ReconciliationFailedReason represents the fact that the
+	// reconciliation of the Kustomization has failed.
+	ReconciliationFailedReason string = "ReconciliationFailed"
 
-	// PruneFailedReason represents the fact that the kustomization pruning failed.
-	PruneFailedReason string = "PruneFailed"
-
-	// ArtifactFailedReason represents the fact that the artifact download failed.
-	ArtifactFailedReason string = "ArtifactFailed"
-
-	// BuildFailedReason represents the fact that the kustomize build command failed.
-	BuildFailedReason string = "BuildFailed"
-
-	// DependencyNotReady represents the fact that the one of the dependencies is not ready.
-	DependencyNotReadyReason string = "DependencyNotReady"
-
-	// HealthCheckFailedReason represents the fact that the one of the health check failed.
-	HealthCheckFailedReason string = "HealthCheckFailed"
-
-	// InitializedReason represents the fact that a given resource has been initialized.
-	InitializedReason string = "Initialized"
-
-	// ProgressingReason represents the fact that a kustomization reconciliation
-	// is underway.
+	// ProgressingReason represents the fact that the
+	// reconciliation of the Kustomization is underway.
 	ProgressingReason string = "Progressing"
 
-	// SuspendedReason represents the fact that the kustomization execution is suspended.
+	// SuspendedReason represents the fact that the
+	// reconciliation of the Kustomization has been suspended.
 	SuspendedReason string = "Suspended"
 
-	// ValidationFailedReason represents the fact that the dry-run apply failed.
+	// DependencyNotReady represents the fact that
+	// one of the dependencies of the Kustomization is not ready.
+	DependencyNotReadyReason string = "DependencyNotReady"
+
+	// PruneFailedReason represents the fact that the
+	// pruning of the Kustomization failed.
+	PruneFailedReason string = "PruneFailed"
+
+	// ArtifactFailedReason represents the fact that the
+	// artifact download of the kustomization failed.
+	ArtifactFailedReason string = "ArtifactFailed"
+
+	// BuildFailedReason represents the fact that the
+	// kustomize build of the Kustomization failed.
+	BuildFailedReason string = "BuildFailed"
+
+	// HealthCheckFailedReason represents the fact that
+	// one of the health checks of the Kustomization failed.
+	HealthCheckFailedReason string = "HealthCheckFailed"
+
+	// ValidationFailedReason represents the fact that the
+	// validation of the Kustomization manifests has failed.
 	ValidationFailedReason string = "ValidationFailed"
 )

--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -26,8 +26,11 @@ import (
 	"github.com/fluxcd/pkg/runtime/dependency"
 )
 
-const KustomizationKind = "Kustomization"
-const KustomizationFinalizer = "finalizers.fluxcd.io"
+const (
+	KustomizationKind         = "Kustomization"
+	KustomizationFinalizer    = "finalizers.fluxcd.io"
+	MaxConditionMessageLength = 4000
+)
 
 // KustomizationSpec defines the desired state of a kustomization.
 type KustomizationSpec struct {
@@ -153,7 +156,7 @@ func SetKustomizationCondition(k *Kustomization, condition string, status corev1
 		Status:             status,
 		LastTransitionTime: metav1.Now(),
 		Reason:             reason,
-		Message:            message,
+		Message:            trimString(message, MaxConditionMessageLength),
 	})
 }
 
@@ -258,4 +261,17 @@ func filterOutCondition(conditions []Condition, condition string) []Condition {
 		newConditions = append(newConditions, c)
 	}
 	return newConditions
+}
+
+func trimString(str string, limit int) string {
+	result := str
+	chars := 0
+	for i := range str {
+		if chars >= limit {
+			result = str[:i] + "..."
+			break
+		}
+		chars++
+	}
+	return result
 }

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -266,7 +266,7 @@ func (r *KustomizationReconciler) reconcile(
 			kustomization,
 			source.GetArtifact().Revision,
 			kustomizev1.ArtifactFailedReason,
-			"artifact acquisition failed",
+			err.Error(),
 		), err
 	}
 
@@ -289,7 +289,7 @@ func (r *KustomizationReconciler) reconcile(
 			kustomization,
 			source.GetArtifact().Revision,
 			kustomizev1.BuildFailedReason,
-			"kustomize create failed",
+			err.Error(),
 		), err
 	}
 
@@ -300,7 +300,7 @@ func (r *KustomizationReconciler) reconcile(
 			kustomization,
 			source.GetArtifact().Revision,
 			kustomizev1.BuildFailedReason,
-			"kustomize build failed",
+			err.Error(),
 		), err
 	}
 
@@ -311,7 +311,7 @@ func (r *KustomizationReconciler) reconcile(
 			kustomization,
 			source.GetArtifact().Revision,
 			kustomizev1.ValidationFailedReason,
-			fmt.Sprintf("%s-side validation failed", kustomization.Spec.Validation),
+			err.Error(),
 		), err
 	}
 
@@ -321,8 +321,8 @@ func (r *KustomizationReconciler) reconcile(
 		return kustomizev1.KustomizationNotReady(
 			kustomization,
 			source.GetArtifact().Revision,
-			kustomizev1.ApplyFailedReason,
-			"apply failed",
+			kustomizev1.ReconciliationFailedReason,
+			err.Error(),
 		), err
 	}
 
@@ -345,7 +345,7 @@ func (r *KustomizationReconciler) reconcile(
 			snapshot,
 			source.GetArtifact().Revision,
 			kustomizev1.HealthCheckFailedReason,
-			"health check failed",
+			err.Error(),
 		), err
 	}
 
@@ -353,7 +353,7 @@ func (r *KustomizationReconciler) reconcile(
 		kustomization,
 		snapshot,
 		source.GetArtifact().Revision,
-		kustomizev1.ApplySucceededReason,
+		kustomizev1.ReconciliationSucceededReason,
 		"Applied revision: "+source.GetArtifact().Revision,
 	), nil
 }

--- a/controllers/kustomization_controller_test.go
+++ b/controllers/kustomization_controller_test.go
@@ -178,7 +178,7 @@ metadata:
 `,
 					},
 				},
-				waitForReason:  kustomizev1.ApplySucceededReason,
+				waitForReason:  kustomizev1.ReconciliationSucceededReason,
 				expectStatus:   corev1.ConditionTrue,
 				expectRevision: "branch/commit1",
 			}),

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -2,8 +2,10 @@
 
 To release a new version the following steps should be followed:
 
+1. Create a `api/<next semver>` tag and push it to remote.
 1. Create a new branch from `master` i.e. `release-<next semver>`. This
    will function as your release preparation branch.
+1. Update the `github.com/fluxcd/kustomize-controller/api` version in `go.mod`
 1. Add an entry to the `CHANGELOG.md` for the new release and change the
    `newTag` value in ` config/manager/kustomization.yaml` to that of the
    semver release you are going to make. Commit and push your changes.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -37,6 +37,7 @@ that describes a pipeline such as:
 - **fetch** manifests from Git repository X
 - **generate** a kustomization if needed
 - **build** the manifest using kustomization X
+- **decrypt** Kubernetes secrets using Mozilla SOPS
 - **validate** the resulting objects 
 - **apply** the objects 
 - **prune** the objects removed from source

--- a/docs/spec/v1alpha1/README.md
+++ b/docs/spec/v1alpha1/README.md
@@ -13,6 +13,7 @@ of Kubernetes objects generated with Kustomize.
     + [Health assessment](kustomization.md#health-assessment)
     + [Kustomization dependencies](kustomization.md#kustomization-dependencies)
     + [Role-based access control](kustomization.md#role-based-access-control)
+    + [Secrets decryption](kustomization.md#secrets-decryption)
     + [Status](kustomization.md#status)
 
 ## Implementation


### PR DESCRIPTION
Changes:
- use reconciliation instead of apply for condition reasons
- add the reconciliation errors to the condition message
- trim the condition message to 4000 characters
- update the API docs and readme with the new condition reasons
- add the API package to release docs