### PR TITLE
Implement namespace overriding

### DIFF
--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -74,6 +74,14 @@ type KustomizationSpec struct {
 	// +optional
 	Suspend bool `json:"suspend,omitempty"`
 
+	// TargetNamespace sets or overrides the namespace in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Optional
+	// +optional
+	TargetNamespace string `json:"targetNamespace,omitempty"`
+
 	// Timeout for validation, apply and health checking operations.
 	// Defaults to 'Interval' duration.
 	// +optional

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -164,6 +164,11 @@ spec:
                   kustomize executions, it does not apply to already started executions.
                   Defaults to false.
                 type: boolean
+              targetNamespace:
+                description: TargetNamespace sets or overrides the kustomization namespace.
+                maxLength: 63
+                minLength: 1
+                type: string
               timeout:
                 description: Timeout for validation, apply and health checking operations.
                   Defaults to 'Interval' duration.

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -165,7 +165,8 @@ spec:
                   Defaults to false.
                 type: boolean
               targetNamespace:
-                description: TargetNamespace sets or overrides the kustomization namespace.
+                description: TargetNamespace sets or overrides the namespace in the
+                  kustomization.yaml file.
                 maxLength: 63
                 minLength: 1
                 type: string

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -76,6 +76,10 @@ func (kg *KustomizeGenerator) WriteFile(dirPath string) (string, error) {
 		}
 	}
 
+	if kg.kustomization.Spec.TargetNamespace != "" {
+		kus.Namespace = kg.kustomization.Spec.TargetNamespace
+	}
+
 	kd, err := yaml.Marshal(kus)
 	if err != nil {
 		return "", err

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -189,6 +189,18 @@ it does not apply to already started executions. Defaults to false.</p>
 </tr>
 <tr>
 <td>
+<code>targetNamespace</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetNamespace sets or overrides the kustomization namespace.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>timeout</code><br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
@@ -634,6 +646,18 @@ bool
 <em>(Optional)</em>
 <p>This flag tells the controller to suspend subsequent kustomize executions,
 it does not apply to already started executions. Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetNamespace</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetNamespace sets or overrides the kustomization namespace.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -196,7 +196,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetNamespace sets or overrides the kustomization namespace.</p>
+<p>TargetNamespace sets or overrides the namespace in the
+kustomization.yaml file.</p>
 </td>
 </tr>
 <tr>
@@ -657,7 +658,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetNamespace sets or overrides the kustomization namespace.</p>
+<p>TargetNamespace sets or overrides the namespace in the
+kustomization.yaml file.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1alpha1/kustomization.md
+++ b/docs/spec/v1alpha1/kustomization.md
@@ -51,6 +51,11 @@ type KustomizationSpec struct {
 	// +optional
 	Suspend bool `json:"suspend,omitempty"`
 
+	// TargetNamespace sets or overrides the namespace in the
+	// kustomization.yaml file.
+	// +optional
+	TargetNamespace string `json:"targetNamespace,omitempty"`
+
 	// Timeout for validation, apply and health checking operations.
 	// Defaults to 'Interval' duration.
 	// +optional


### PR DESCRIPTION
Changes:
- Add `TargetNamespace` field to API and docs
- Implement namespace overriding

This PR allows setting or overriding the namespace in the` kustomization.yaml`, making possible for cluster admins to onboard external apps into existing namespaces. This will also open the path to create ephemeral namespaces for PR reviews. 