### PR TITLE
Record last handled reconcile at annotation

### DIFF
--- a/api/v1alpha1/kustomization_types.go
+++ b/api/v1alpha1/kustomization_types.go
@@ -135,6 +135,11 @@ type KustomizationStatus struct {
 	// +optional
 	LastAttemptedRevision string `json:"lastAttemptedRevision,omitempty"`
 
+	// LastHandledReconcileAt is the last manual reconciliation request (by
+	// annotating the Kustomization) handled by the reconciler.
+	// +optional
+	LastHandledReconcileAt string `json:"lastHandledReconcileAt,omitempty"`
+
 	// The last successfully applied revision metadata.
 	// +optional
 	Snapshot *Snapshot `json:"snapshot,omitempty"`

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -228,6 +228,10 @@ spec:
                 description: LastAttemptedRevision is the revision of the last reconciliation
                   attempt.
                 type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt is the last manual reconciliation
+                  request (by annotating the Kustomization) handled by the reconciler.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the last reconciled generation.
                 format: int64

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -763,6 +763,19 @@ string
 </tr>
 <tr>
 <td>
+<code>lastHandledReconcileAt</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastHandledReconcileAt is the last manual reconciliation request (by
+annotating the Kustomization) handled by the reconciler.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>snapshot</code><br>
 <em>
 <a href="#kustomize.toolkit.fluxcd.io/v1alpha1.Snapshot">

--- a/docs/spec/v1alpha1/kustomization.md
+++ b/docs/spec/v1alpha1/kustomization.md
@@ -104,6 +104,11 @@ type KustomizationStatus struct {
 	// +optional
 	LastAttemptedRevision string `json:"lastAttemptedRevision,omitempty"`
 
+	// LastHandledReconcileAt is the last manual reconciliation request (by
+	// annotating the Kustomization) handled by the reconciler.
+	// +optional
+	LastHandledReconcileAt string `json:"lastHandledReconcileAt,omitempty"`
+
 	// The last successfully applied revision metadata.
 	// +optional
 	Snapshot *Snapshot `json:"snapshot"`


### PR DESCRIPTION
This makes it possible for e.g. the GOTK CLI to observe if the controller has handled the resource since the manual reconciliation request was made.

Ref: https://github.com/fluxcd/toolkit/discussions/217