### PR TITLE
Fix status reporting when the source is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 IMG ?= fluxcd/kustomize-controller:latest
 # Produce CRDs that work back to Kubernetes 1.16
 CRD_OPTIONS ?= crd:crdVersions=v1
-SOURCE_VER ?= v0.1.0
+SOURCE_VER ?= v0.1.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-- github.com/fluxcd/source-controller/config//crd?ref=v0.1.0
-- github.com/fluxcd/source-controller/config//manager?ref=v0.1.0
+- github.com/fluxcd/source-controller/config//crd?ref=v0.1.1
+- github.com/fluxcd/source-controller/config//manager?ref=v0.1.1
 - namespace.yaml


### PR DESCRIPTION
When the source is not found the status wasn't updated accordingly. 