### PR TITLE
Suppress health check events when no changes made

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -753,7 +753,7 @@ func (r *KustomizationReconciler) checkHealth(statusPoller *polling.StatusPoller
 		return err
 	}
 
-	if kustomization.Status.LastAppliedRevision != revision && (changed || len(kustomization.Spec.DependsOn) > 0) {
+	if kustomization.Status.LastAppliedRevision != revision && changed {
 		r.event(kustomization, revision, events.EventSeverityInfo, "Health check passed", nil)
 	}
 	return nil


### PR DESCRIPTION
When no Kubernetes resources are created or configured for a `Kustomization` and it has no dependencies, the health check status for the `Kustomization` will not change.
In this case kustomize-controller does not have to deliver health check events.
What do you think?