### PR TITLE
Allow disabling validation

### DIFF
--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -93,8 +93,8 @@ type KustomizationSpec struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
 	// Validate the Kubernetes objects before applying them on the cluster.
-	// The validation strategy can be 'client' (local dry-run) or 'server' (APIServer dry-run).
-	// +kubebuilder:validation:Enum=client;server
+	// The validation strategy can be 'client' (local dry-run), 'server' (APIServer dry-run) or 'none'.
+	// +kubebuilder:validation:Enum=none;client;server
 	// +optional
 	Validation string `json:"validation,omitempty"`
 }

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -196,9 +196,10 @@ spec:
                 type: string
               validation:
                 description: Validate the Kubernetes objects before applying them
-                  on the cluster. The validation strategy can be 'client' (local dry-run)
-                  or 'server' (APIServer dry-run).
+                  on the cluster. The validation strategy can be 'client' (local dry-run),
+                  'server' (APIServer dry-run) or 'none'.
                 enum:
+                - none
                 - client
                 - server
                 type: string

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -569,7 +569,7 @@ func (r *KustomizationReconciler) reconcileDelete(ctx context.Context, log logr.
 }
 
 func (r *KustomizationReconciler) validate(kustomization kustomizev1.Kustomization, dirPath string) error {
-	if kustomization.Spec.Validation == "" {
+	if kustomization.Spec.Validation == "" || kustomization.Spec.Validation == "none" {
 		return nil
 	}
 

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -239,7 +239,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Validate the Kubernetes objects before applying them on the cluster.
-The validation strategy can be &lsquo;client&rsquo; (local dry-run) or &lsquo;server&rsquo; (APIServer dry-run).</p>
+The validation strategy can be &lsquo;client&rsquo; (local dry-run), &lsquo;server&rsquo; (APIServer dry-run) or &lsquo;none&rsquo;.</p>
 </td>
 </tr>
 </table>
@@ -672,7 +672,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Validate the Kubernetes objects before applying them on the cluster.
-The validation strategy can be &lsquo;client&rsquo; (local dry-run) or &lsquo;server&rsquo; (APIServer dry-run).</p>
+The validation strategy can be &lsquo;client&rsquo; (local dry-run), &lsquo;server&rsquo; (APIServer dry-run) or &lsquo;none&rsquo;.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -66,8 +66,8 @@ type KustomizationSpec struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
 	// Validate the Kubernetes objects before applying them on the cluster.
-	// The validation strategy can be 'client' (local dry-run) or 'server' (APIServer dry-run).
-	// +kubebuilder:validation:Enum=client;server
+	// The validation strategy can be 'client' (local dry-run), 'server' (APIServer dry-run) or 'none'.
+	// +kubebuilder:validation:Enum=none;client;server
 	// +optional
 	Validation string `json:"validation,omitempty"`
 }


### PR DESCRIPTION
This PR adds `none` to the list of accepted values for `spec.validation`, this allows users to explicitly disable the dry-run apply.