### PR TITLE
Set --field-manager when applying

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -682,9 +682,10 @@ func (r *KustomizationReconciler) apply(kustomization kustomizev1.Kustomization,
 	timeout := kustomization.GetTimeout() + (time.Second * 1)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	fieldManager := "kustomize-controller"
 
-	cmd := fmt.Sprintf("cd %s && kubectl apply -f %s.yaml --timeout=%s --cache-dir=/tmp",
-		dirPath, kustomization.GetUID(), kustomization.Spec.Interval.Duration.String())
+	cmd := fmt.Sprintf("cd %s && kubectl apply --field-manager=%s -f %s.yaml --timeout=%s --cache-dir=/tmp",
+		dirPath, fieldManager, kustomization.GetUID(), kustomization.Spec.Interval.Duration.String())
 
 	if kustomization.Spec.KubeConfig != nil {
 		kubeConfig, err := r.writeKubeConfig(kustomization, dirPath)


### PR DESCRIPTION
This would allows to have more details when using the [kubectl blame](https://github.com/knight42/kubectl-blame) plugin.

At the moment a deployment managed by kustomize would look like this:

<details><summary>CLICK ME</summary><p>

```
                                                             apiVersion: apps/v1
                                                             kind: Deployment
                                                             metadata:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)   annotations:
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     deployment.kubernetes.io/revision: "1"
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)   labels:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     app: go-lev
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     kustomize.toolkit.fluxcd.io/checksum: 1f9831532b54595a131456fd03a7e7ed0afb9b74
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     kustomize.toolkit.fluxcd.io/name: default
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     kustomize.toolkit.fluxcd.io/namespace: flux
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     maintainer: team-ops
                                                               name: go-lev
                                                               namespace: default
                                                               resourceVersion: "4539586"
                                                               selfLink: /apis/apps/v1/namespaces/default/deployments/go-lev
                                                               uid: 3c947693-e9a8-408b-b049-ebed63ad21e4
                                                             spec:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)   progressDeadlineSeconds: 600
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)   replicas: 2
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)   revisionHistoryLimit: 10
                                                               selector:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     matchLabels:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       app: go-lev
                                                               strategy:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     rollingUpdate:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       maxSurge: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       maxUnavailable: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)     type: RollingUpdate
                                                               template:
                                                                 metadata:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       annotations:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         prometheus.io/path: /metrics
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         prometheus.io/port: "8080"
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         prometheus.io/scrape: "false"
                                                                   creationTimestamp: null
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       labels:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         app: go-lev
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         maintainer: team-ops
                                                                 spec:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       affinity:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         podAntiAffinity:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           preferredDuringSchedulingIgnoredDuringExecution:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           - podAffinityTerm:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)               labelSelector:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)                 matchExpressions:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)                 - key: app
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)                   operator: In
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)                   values:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)                   - go-lev
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)               topologyKey: kubernetes.io/hostname
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             weight: 100
                                                                   containers:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       - env:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         - name: INSTANA_AGENT_HOST
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           valueFrom:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             fieldRef:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)               apiVersion: v1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)               fieldPath: status.hostIP
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         image: quay.io/sylr/go-lev:instana
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         imagePullPolicy: Always
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         livenessProbe:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           failureThreshold: 10
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           httpGet:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             path: /ping
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             port: 8080
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             scheme: HTTP
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           initialDelaySeconds: 3
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           periodSeconds: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           successThreshold: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           timeoutSeconds: 2
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         name: go-lev
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         ports:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         - containerPort: 8080
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           name: http
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           protocol: TCP
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         readinessProbe:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           failureThreshold: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           httpGet:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             path: /ready
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             port: 8080
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             scheme: HTTP
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           initialDelaySeconds: 3
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           periodSeconds: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           successThreshold: 1
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           timeoutSeconds: 2
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         resources:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           limits:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             cpu: "1"
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             memory: 128Mi
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)           requests:
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             cpu: 100m
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)             memory: 64Mi
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         terminationMessagePath: /dev/termination-log
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)         terminationMessagePolicy: File
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       dnsPolicy: ClusterFirst
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       restartPolicy: Always
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       schedulerName: default-scheduler
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       securityContext: {}
kubectl-client-side-apply (Update 2020-11-18 14:07:18 +0100)       terminationGracePeriodSeconds: 30
                                                             status:
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   availableReplicas: 2
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   conditions:
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   - lastTransitionTime: "2020-11-17T16:20:56Z"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     lastUpdateTime: "2020-11-17T16:20:56Z"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     message: Deployment has minimum availability.
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     reason: MinimumReplicasAvailable
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     status: "True"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     type: Available
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   - lastTransitionTime: "2020-11-17T16:20:26Z"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     lastUpdateTime: "2020-11-17T16:20:57Z"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     message: ReplicaSet "go-lev-7df78f6b58" has successfully progressed.
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     reason: NewReplicaSetAvailable
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     status: "True"
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)     type: Progressing
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   observedGeneration: 2
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   readyReplicas: 2
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   replicas: 2
kube-controller-manager   (Update 2020-11-18 14:07:18 +0100)   updatedReplicas: 2
```

</p></details>

This patch should replace the default `kubectl-client-side-apply` by `kustomize-controller/<gitrevision>`.

What do you think ?