### PR TITLE
Emit healthcheck event when Kustomization was not ready

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -815,7 +815,10 @@ func (r *KustomizationReconciler) checkHealth(statusPoller *polling.StatusPoller
 		return err
 	}
 
-	if kustomization.Status.LastAppliedRevision != revision && changed {
+	readiness := apimeta.FindStatusCondition(kustomization.Status.Conditions, meta.ReadyCondition)
+	ready := readiness != nil && readiness.Status == metav1.ConditionTrue
+
+	if !ready || (kustomization.Status.LastAppliedRevision != revision && changed) {
 		r.event(kustomization, revision, events.EventSeverityInfo, "Health check passed", nil)
 	}
 	return nil


### PR DESCRIPTION
Healthcheck can temporarily fail due to slow application startup, network failure, etc.
In this case, Flux emits an event of the failed healthcheck.
But when the healthcheck passes in another reconciliation, the current implementation does not emit a healthcheck event because the revision has not changed.

This PR fixes this behavior.
Flux will always emit a healthcheck event if a Kustomization was not ready in the previous reconciliation.