### PR TITLE
No longer treat dirs as kustomization files

### DIFF
--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -145,7 +145,7 @@ func (kg *KustomizeGenerator) generateKustomization(dirPath string) error {
 				// If a sub-directory contains an existing kustomization file add the
 				// directory as a resource and do not decend into it.
 				for _, kfilename := range konfig.RecognizedKustomizationFileNames() {
-					if fs.Exists(filepath.Join(path, kfilename)) {
+					if kpath := filepath.Join(path, kfilename); fs.Exists(kpath) && !fs.IsDir(kpath) {
 						paths = append(paths, path)
 						return filepath.SkipDir
 					}


### PR DESCRIPTION
Fixes https://github.com/fluxcd/kustomize-controller/issues/223
Signed-off-by: Michał Flendrich <michal@flendrich.pro>

Before this PR, kustomize-controller (incorrectly) takes a directory named `Kustomization` as a kustomization file, with the following consequences:
- the directory which contains the directory called `Kustomization` is erroneously omitted from processing
- trying to open the `Kustomization` directory as a file results in an error, reported by kustomization-controller

After this PR, when traversing the filesystem tree looking for Kustomization files, kustomization-controller doesn't try to take directories as kustomization files.

Testing: I believe that this change deserves an e2e test case, but apparently, in the current shape of e2e tests, this requires a GitHub repository with a "malicious" directory called Kustomization. I'll happily accept maintainers' guidance as to possible ways to test this change.