### PR TITLE
Update kustomize/api to v0.7.2 and disable kyaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 
 RUN apk add --no-cache ca-certificates curl
 
-RUN kubectl_ver=1.20.1 && \
+RUN kubectl_ver=1.20.2 && \
 arch=${TARGETPLATFORM:-linux/amd64} && \
 if [ "$TARGETPLATFORM" == "linux/arm/v7" ]; then arch="linux/arm"; fi && \
 curl -sL https://storage.googleapis.com/kubernetes-release/release/v${kubectl_ver}/bin/${arch}/kubectl \

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/krusty"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 
@@ -507,10 +508,17 @@ func (r *KustomizationReconciler) build(kustomization kustomizev1.Kustomization,
 	fs := filesys.MakeFsOnDisk()
 	manifestsFile := filepath.Join(dirPath, fmt.Sprintf("%s.yaml", kustomization.GetUID()))
 
-	opt := krusty.MakeDefaultOptions()
-	opt.LoadRestrictions = kustypes.LoadRestrictionsNone
-	opt.DoLegacyResourceSort = true
-	k := krusty.MakeKustomizer(fs, opt)
+	buildOptions := &krusty.Options{
+		DoLegacyResourceSort:   true,
+		AddManagedbyLabel:      false,
+		LoadRestrictions:       kustypes.LoadRestrictionsNone,
+		DoPrune:                false,
+		PluginConfig:           konfig.DisabledPluginConfig(),
+		UseKyaml:               false,
+		AllowResourceIdChanges: false,
+	}
+
+	k := krusty.MakeKustomizer(fs, buildOptions)
 	m, err := k.Run(dirPath)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,6 @@ require (
 	k8s.io/client-go v0.20.2
 	sigs.k8s.io/cli-utils v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.0
-	sigs.k8s.io/kustomize/api v0.7.1
+	sigs.k8s.io/kustomize/api v0.7.2
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1227,11 +1227,11 @@ sigs.k8s.io/controller-runtime v0.8.0 h1:s0dYdo7lQgJiAf+alP82PRwbz+oAqL3oSyMQ18X
 sigs.k8s.io/controller-runtime v0.8.0/go.mod h1:v9Lbj5oX443uR7GXYY46E0EE2o7k2YxQ58GxVNeXSW4=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/api v0.7.1 h1:/cjDi4Pk/hqRSeCCj/Xum66rYrEtc7osM2/O+lvYKkM=
-sigs.k8s.io/kustomize/api v0.7.1/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
+sigs.k8s.io/kustomize/api v0.7.2 h1:ItTD/2XaKO8CosOMFZdaGFdUGTCHdQriW7zQ7AR98rs=
+sigs.k8s.io/kustomize/api v0.7.2/go.mod h1:50/vLATrjhRmMr3spZsI1GcpoZJ8IARy9QstPbA9lGE=
 sigs.k8s.io/kustomize/kyaml v0.8.1/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
-sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
-sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
+sigs.k8s.io/kustomize/kyaml v0.10.6 h1:xUJxc/k8JoWqHUahaB8DTqY0KwEPxTbTGStvW8TOcDc=
+sigs.k8s.io/kustomize/kyaml v0.10.6/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=


### PR DESCRIPTION
This PR updates `kustomize/api` to v0.7.2 and disables `kyaml` when running kustomize build due to upstream bugs:
- https://github.com/kubernetes-sigs/kustomize/issues/3446
- https://github.com/kubernetes-sigs/kustomize/issues/3480

Note that when `kyaml` is enabled, `Kustomizer.Run` fails with `Error: json: unsupported type: map[interface {}]interface {}` without any hint to which object caused the error, making it impossible for Flux users to track down the incompatible manifest.

Also if a manifest contains duplicate keys, kyaml panics thus crashing the whole controller 😢 

Fix: https://github.com/fluxcd/flux2/issues/729
Fix: #243 