### PR TITLE
Allow failed reconciliations to be scheduled at a different interval 

### DIFF
--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -48,6 +48,11 @@ type KustomizationSpec struct {
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
+	// The interval at which to retry a previously failed reconciliation.
+	// When not specified, it defaults to the Interval value.
+	// +optional
+	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
+
 	// The KubeConfig for reconciling the Kustomization on a remote cluster.
 	// When specified, KubeConfig takes precedence over ServiceAccountName.
 	// +optional
@@ -222,6 +227,14 @@ func (in Kustomization) GetTimeout() time.Duration {
 		return time.Minute
 	}
 	return duration
+}
+
+// GetRetryInterval returns the retry interval
+func (in Kustomization) GetRetryInterval() time.Duration {
+	if in.Spec.RetryInterval != nil {
+		return in.Spec.RetryInterval.Duration
+	}
+	return in.Spec.Interval.Duration
 }
 
 func (in Kustomization) GetDependsOn() (types.NamespacedName, []dependency.CrossNamespaceDependencyReference) {

--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -49,7 +49,8 @@ type KustomizationSpec struct {
 	Interval metav1.Duration `json:"interval"`
 
 	// The interval at which to retry a previously failed reconciliation.
-	// When not specified, it defaults to the Interval value.
+	// When not specified, the controller uses the KustomizationSpec.Interval
+	// value to retry failures.
 	// +optional
 	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -166,6 +166,11 @@ func (in *KustomizationSpec) DeepCopyInto(out *KustomizationSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.Interval = in.Interval
+	if in.RetryInterval != nil {
+		in, out := &in.RetryInterval, &out.RetryInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
 		*out = new(KubeConfig)

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -173,7 +173,8 @@ spec:
                 type: boolean
               retryInterval:
                 description: The interval at which to retry a previously failed reconciliation.
-                  When not specified, it defaults to the Interval value.
+                  When not specified, the controller uses the KustomizationSpec.Interval
+                  value to retry failures.
                 type: string
               serviceAccountName:
                 description: The name of the Kubernetes service account to impersonate

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -171,6 +171,10 @@ spec:
               prune:
                 description: Prune enables garbage collection.
                 type: boolean
+              retryInterval:
+                description: The interval at which to retry a previously failed reconciliation.
+                  When not specified, it defaults to the Interval value.
+                type: string
               serviceAccountName:
                 description: The name of the Kubernetes service account to impersonate
                   when reconciling this Kustomization.

--- a/controllers/kustomization_controller_test.go
+++ b/controllers/kustomization_controller_test.go
@@ -190,6 +190,11 @@ var _ = Describe("KustomizationReconciler", func() {
 
 			Expect(cond.Status).To(Equal(t.expectStatus))
 			Expect(got.Status.LastAppliedRevision).To(Equal(t.expectRevision))
+
+			ns := &corev1.Namespace{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "test"}, ns)).Should(Succeed())
+			Expect(ns.Labels[fmt.Sprintf("%s/name", kustomizev1.GroupVersion.Group)]).To(Equal(kName.Name))
+			Expect(ns.Labels[fmt.Sprintf("%s/namespace", kustomizev1.GroupVersion.Group)]).To(Equal(kName.Namespace))
 		},
 			Entry("namespace-sa", refTestCase{
 				artifacts: []testserver.File{

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -123,7 +123,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>The interval at which to retry a previously failed reconciliation.
-When not specified, it defaults to the Interval value.</p>
+When not specified, the controller uses the KustomizationSpec.Interval
+value to retry failures.</p>
 </td>
 </tr>
 <tr>
@@ -574,7 +575,8 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>The interval at which to retry a previously failed reconciliation.
-When not specified, it defaults to the Interval value.</p>
+When not specified, the controller uses the KustomizationSpec.Interval
+value to retry failures.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -113,6 +113,21 @@ Kubernetes meta/v1.Duration
 </tr>
 <tr>
 <td>
+<code>retryInterval</code><br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The interval at which to retry a previously failed reconciliation.
+When not specified, it defaults to the Interval value.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>kubeConfig</code><br>
 <em>
 <a href="#kustomize.toolkit.fluxcd.io/v1beta1.KubeConfig">
@@ -545,6 +560,21 @@ Kubernetes meta/v1.Duration
 </td>
 <td>
 <p>The interval at which to reconcile the Kustomization.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retryInterval</code><br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The interval at which to retry a previously failed reconciliation.
+When not specified, it defaults to the Interval value.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -26,7 +26,8 @@ type KustomizationSpec struct {
 	Interval metav1.Duration `json:"interval"`
 
 	// The interval at which to retry a previously failed reconciliation.
-	// When not specified, it defaults to the Interval value.
+	// When not specified, the controller uses the KustomizationSpec.Interval
+	// value to retry failures.
 	// +optional
 	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 	

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -25,6 +25,11 @@ type KustomizationSpec struct {
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
+	// The interval at which to retry a previously failed reconciliation.
+	// When not specified, it defaults to the Interval value.
+	// +optional
+	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
+	
 	// The KubeConfig for reconciling the Kustomization on a remote cluster.
 	// When specified, KubeConfig takes precedence over ServiceAccountName.
 	// +optional


### PR DESCRIPTION
This PR adds an optional field `spec.retryInterval ` to the API that allows users to requeue a failed reconciliation at a different interval than `spec.Interval`.

Changes:
- Add `RetryInterval` as optional field to API. The spec.retryInterval is the interval at which to retry a previously failed reconciliation. When not specified, it defaults to the `spec.interval` value.
- Requeue a failed reconciliation based on retry interval 
- Add reconciliation unit test to verify that objects are create in cluster and labeled accordingly
 
 Fix: #246