### PR TITLE
Add tests for reconciliation events

### DIFF
--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -101,6 +101,7 @@ type KustomizationSpec struct {
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	// Timeout for validation, apply and health checking operations.
+	// Will default to 1 min if set to less than 1 min.
 	// Defaults to 'Interval' duration.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -217,7 +217,8 @@ spec:
                 type: string
               timeout:
                 description: Timeout for validation, apply and health checking operations.
-                  Defaults to 'Interval' duration.
+                  Will default to 1 min if set to less than 1 min. Defaults to 'Interval'
+                  duration.
                 type: string
               validation:
                 description: Validate the Kubernetes objects before applying them

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -91,10 +92,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&KustomizationReconciler{
-		Client:                k8sManager.GetClient(),
-		Scheme:                scheme.Scheme,
-		EventRecorder:         k8sManager.GetEventRecorderFor("kustomize-controller"),
-		ExternalEventRecorder: nil,
+		Client:        k8sManager.GetClient(),
+		Scheme:        scheme.Scheme,
+		EventRecorder: k8sManager.GetEventRecorderFor("kustomize-controller"),
+		StatusPoller:  polling.NewStatusPoller(k8sManager.GetClient(), k8sManager.GetRESTMapper()),
 	}).SetupWithManager(k8sManager, KustomizationReconcilerOptions{MaxConcurrentReconciles: 1})
 	Expect(err).ToNot(HaveOccurred(), "failed to setup KustomizationReconciler")
 

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -259,6 +259,7 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>Timeout for validation, apply and health checking operations.
+Will default to 1 min if set to less than 1 min.
 Defaults to &lsquo;Interval&rsquo; duration.</p>
 </td>
 </tr>
@@ -711,6 +712,7 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>Timeout for validation, apply and health checking operations.
+Will default to 1 min if set to less than 1 min.
 Defaults to &lsquo;Interval&rsquo; duration.</p>
 </td>
 </tr>


### PR DESCRIPTION
This adds tests that are meant to standardize the expected behavior for events generated by KC. In the end the test should act as a guide for any future changes to how events are generated.

Steps:
1. Create Kustomization which will deploy a Pod
2. Set Pod to an unhealthy state and wait for Kustomization to receive status condition for failed health check.
3. Trigger a reconcile and check the events to make sure that only one event has been created for the failed health check.
4. Set Pod to a healthy state and wait for Kustomization to receive a healthy status condition
5. Trigger a reconcile and check the events to make sure that only one event has been created for the health check.

TBD:
1. Verify external event recorder event message matches status
2. Update revision and make sure only one event is created for health check.