### PR TITLE
impersonation: Clear config.BearerTokenFile when setting BearerToken.

### DIFF
--- a/controllers/kustomization_impersonation.go
+++ b/controllers/kustomization_impersonation.go
@@ -119,6 +119,7 @@ func (ki *KustomizeImpersonation) clientForServiceAccount(ctx context.Context) (
 		return nil, nil, err
 	}
 	restConfig.BearerToken = token
+	restConfig.BearerTokenFile = "" // Clear, as it overrides BearerToken
 
 	restMapper, err := apiutil.NewDynamicRESTMapper(restConfig)
 	if err != nil {


### PR DESCRIPTION
When running in a cluster, the BearerTokenFile is set to point to
`/var/run/secrets/kubernetes.io/serviceaccount/token` where the service
account's token is auto-mounted. If this value is not cleared, the
setting of the BearerToken field will have no effect. Relevant
documentation:
https://pkg.go.dev/k8s.io/client-go@v0.20.2/rest#Config.BearerTokenFile