### PR TITLE
Support impersonation for validation

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -553,6 +553,16 @@ func (r *KustomizationReconciler) validate(ctx context.Context, kustomization ku
 			return err
 		}
 		cmd = fmt.Sprintf("%s --kubeconfig=%s", cmd, kubeConfig)
+	} else {
+		// impersonate SA
+		if kustomization.Spec.ServiceAccountName != "" {
+			saToken, err := imp.GetServiceAccountToken(ctx)
+			if err != nil {
+				return fmt.Errorf("service account impersonation failed: %w", err)
+			}
+
+			cmd = fmt.Sprintf("%s --token %s", cmd, saToken)
+		}
 	}
 
 	command := exec.CommandContext(applyCtx, "/bin/sh", "-c", cmd)


### PR DESCRIPTION
Having a similar setup as in https://github.com/fluxcd/kustomize-controller/issues/217. Running kustomize-controller with minimal privileges and using `serviceAccountName` to "elevate" privileges for Kustomizations.

Kustomization validation was performed with the kustomize-controller service account, which with the above setup doesn't have the required privileges. This PR adds support for service account impersonation during validation.

Same approach as for apply(): https://github.com/splushii/kustomize-controller/blob/d0f2dc6e4aab2cd6dd454adec0698d5ea2bd644e/controllers/kustomization_controller.go#L595-L604