### PR TITLE
Add Healthy status condition

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -17,6 +17,10 @@ limitations under the License.
 package v1beta1
 
 const (
+	// HealthyCondition is the condition type used
+	// to record the last health assessment result.
+	HealthyCondition string = "Healthy"
+
 	// PruneFailedReason represents the fact that the
 	// pruning of the Kustomization failed.
 	PruneFailedReason string = "PruneFailed"

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -695,10 +695,10 @@ func (r *KustomizationReconciler) checkHealth(ctx context.Context, statusPoller 
 		return err
 	}
 
-	readiness := apimeta.FindStatusCondition(kustomization.Status.Conditions, meta.ReadyCondition)
-	ready := readiness != nil && readiness.Status == metav1.ConditionTrue
+	healthiness := apimeta.FindStatusCondition(kustomization.Status.Conditions, kustomizev1.HealthyCondition)
+	healthy := healthiness != nil && healthiness.Status == metav1.ConditionTrue
 
-	if !ready || (kustomization.Status.LastAppliedRevision != revision && changed) {
+	if !healthy || (kustomization.Status.LastAppliedRevision != revision && changed) {
 		r.event(ctx, kustomization, revision, events.EventSeverityInfo, "Health check passed", nil)
 	}
 	return nil


### PR DESCRIPTION
- record the last health assessment result in a dedicated status condition
- use the condition status when issuing events to prevent notifications spam (fix: #236)
