### PR TITLE
Allow the controller to be run locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,38 @@ You can run the unit tests by simply doing
 make test
 ```
 
+### How to run the controller locally
+
+Install flux on your test cluster:
+
+```sh
+flux install
+```
+
+Scale the in-cluster controller to zero:
+
+```sh
+kubectl -n flux-system scale deployment/kustomize-controller --replicas=0
+```
+
+Port forward to source-controller artifacts server:
+
+```sh
+kubectl -n flux-system port-forward svc/source-controller 8080:80
+```
+
+Export the local address as `SOURCE_CONTROLLER_LOCALHOST`:
+
+```sh
+export SOURCE_CONTROLLER_LOCALHOST=localhost:8080
+```
+
+Run the controller locally:
+
+```sh
+make run
+```
+
 ## Acceptance policy
 
 These things will make a PR more likely to be accepted:

--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -415,6 +415,18 @@ func (r *KustomizationReconciler) download(kustomization kustomizev1.Kustomizati
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	if hostname := os.Getenv("SOURCE_CONTROLLER_LOCALHOST"); hostname != "" {
+		namespace := kustomization.GetNamespace()
+		if kustomization.Spec.SourceRef.Namespace != "" {
+			namespace = kustomization.Spec.SourceRef.Namespace
+		}
+		url = fmt.Sprintf("http://%s/%s/%s/%s/latest.tar.gz",
+			hostname,
+			strings.ToLower(kustomization.Spec.SourceRef.Kind),
+			namespace,
+			kustomization.Spec.SourceRef.Name)
+	}
+
 	// download the tarball
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
This PR makes it possible to run kustomize-controller locally for debugging purposes against a test cluster.