### PR TITLE
Extracting validation error from apply dry run output

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -598,7 +598,7 @@ func (r *KustomizationReconciler) validate(ctx context.Context, kustomization ku
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("validation timeout: %w", err)
 		}
-		return fmt.Errorf("validation failed: %s", string(output))
+		return fmt.Errorf("validation failed: %s", parseApplyError(output))
 	}
 	return nil
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -56,8 +56,11 @@ func parseApplyError(in []byte) string {
 	for _, line := range lines {
 		if line != "" &&
 			!strings.HasSuffix(line, "created") &&
+			!strings.HasSuffix(line, "created (dry run)") &&
 			!strings.HasSuffix(line, "configured") &&
-			!strings.HasSuffix(line, "unchanged") {
+			!strings.HasSuffix(line, "configured (dry run)") &&
+			!strings.HasSuffix(line, "unchanged") &&
+			!strings.HasSuffix(line, "unchanged (dry run)") {
 			errors += line + "\n"
 		}
 	}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_parseApplyError(t *testing.T) {
+	filtered := parseApplyError([]byte(`
+gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged
+ingressroute.traefik.containo.us/flux-receiver configured
+service/notification-controller created
+The Service "webhook-receiver" is invalid: spec.clusterIP: Invalid value: "10.200.133.61": field is immutable`))
+	filtered = strings.TrimSpace(filtered)
+	numLines := len(strings.Split(filtered, "\n"))
+	if numLines != 1 {
+		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
+	}
+}
+
+func Test_parseApplyError_dryRun(t *testing.T) {
+	filtered := parseApplyError([]byte(`
+gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged (dry run)
+ingressroute.traefik.containo.us/flux-receiver configured (dry run)
+service/notification-controller created (dry run)
+error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`))
+	filtered = strings.TrimSpace(filtered)
+	numLines := len(strings.Split(filtered, "\n"))
+	if numLines != 1 {
+		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
+	}
+}


### PR DESCRIPTION
An attempt to treat validation error output the same way as apply output: reducing the noise by only returning the validation error.

Fixes: #277

Note: I'm not sure about the BDD framework used in the project. Let me know if I misuse it