### PR TITLE
Retry with exponential backoff when fetching artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/fluxcd/pkg/untar v0.0.5
 	github.com/fluxcd/source-controller/api v0.9.0
 	github.com/go-logr/logr v0.3.0
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.2

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 		clientOptions        client.Options
 		logOptions           logger.Options
 		watchAllNamespaces   bool
+		httpRetry            int
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -77,6 +78,7 @@ func main() {
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
+	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.Bool("log-json", false, "Set logging to JSON format.")
 	flag.CommandLine.MarkDeprecated("log-json", "Please use --log-encoding=json instead.")
 	clientOptions.BindFlags(flag.CommandLine)
@@ -132,6 +134,7 @@ func main() {
 	}).SetupWithManager(mgr, controllers.KustomizationReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,
+		HTTPRetry:                 httpRetry,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", kustomizev1.KustomizationKind)
 		os.Exit(1)


### PR DESCRIPTION
This PR implements retries with exponential backoff when fetching artifacts from source-controller. By default, the controller does 10 attempts within a 3.5 minutes window, the number of max retries can be configure using the `--http-retry` cmd arg.

This mitigates the alert spam (`i/o timeout err`) when source-controller becomes unavailable for a short period of time e.g. after an upgrade. 

Example error log:

```json
{"level":"error","ts":"2021-02-26T12:03:19.710+0200","logger":"controller.kustomization","msg":"Reconciliation failed after 3m35.317406763s, next try in 5m0s","reconciler group":"kustomize.toolkit.fluxcd.io","reconciler kind":"Kustomization","name":"podinfo","namespace":"flux-system","revision":"master/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7","error":"failed to download artifact, error: GET http://localhost:8080/gitrepository/flux-system/podinfo/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7.tar.gz giving up after 10 attempt(s): Get \"http://localhost:8080/gitrepository/flux-system/podinfo/e43ebfa5bf4b87c46f2e1db495eb571cd398e2f7.tar.gz\": dial tcp [::1]:8080: connect: connection refused"}
```

Ref: https://github.com/fluxcd/flux2/discussions/661 https://github.com/fluxcd/notification-controller/issues/76