### PR TITLE
Validate the var names before substitution

### DIFF
--- a/controllers/kustomization_controller_test.go
+++ b/controllers/kustomization_controller_test.go
@@ -200,7 +200,7 @@ var _ = Describe("KustomizationReconciler", func() {
 					Validation: "client",
 					Force:      false,
 					PostBuild: &kustomizev1.PostBuild{
-						Substitute: map[string]string{"region": "eu-central-1"},
+						Substitute: map[string]string{"_Region": "eu-central-1"},
 						SubstituteFrom: []kustomizev1.SubstituteReference{
 							{
 								Kind: "ConfigMap",
@@ -274,7 +274,7 @@ metadata:
   namespace: test
   labels:
     environment: ${env:=dev}
-    region: "${region}" 
+    region: "${_Region}" 
     zone: "${zone}"
 `,
 					},

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -716,6 +716,10 @@ for [bash string replacement functions](https://github.com/drone/envsubst) e.g.:
 - `${var:position:length}`
 - `${var/substring/replacement}`
 
+Note that the name of a variable can contain only alphanumeric and underscore characters.
+The controller validates the var names using this regular expression:
+`^[_[:alpha:]][_[:alpha:][:digit:]]*$`.
+
 Assuming you have manifests with the following variables:
 
 ```yaml


### PR DESCRIPTION
The name of a variable used in post build substitutions can contain only alphanumeric and underscore characters. This PR implements validation for the variable names using `^[_[:alpha:]][_[:alpha:][:digit:]]*$` regex. 

Fix: #290