### PR TITLE
Detect and replace empty err output on apply

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -659,7 +659,11 @@ func (r *KustomizationReconciler) apply(ctx context.Context, kustomization kusto
 			return "", fmt.Errorf("apply failed: %w, kubectl process was killed, probably due to OOM", err)
 		}
 
-		return "", fmt.Errorf("apply failed: %s", parseApplyError(output))
+		applyErr := parseApplyError(output)
+		if applyErr == "" {
+			applyErr = "no error output found, this may happen because of a timeout"
+		}
+		return "", fmt.Errorf("apply failed: %s", applyErr)
 	}
 
 	resources := parseApplyOutput(output)

--- a/controllers/kustomization_controller_sops_test.go
+++ b/controllers/kustomization_controller_sops_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021it com The Flux authors
+Copyright 2021 The Flux authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This should give users some guidance when `kubectl apply` itself does
not give any useful output back itself, till date only observed when
it times out waiting.

Should help some with #311.