### PR TITLE
Make log level info for 'Dependencies do not meet ready condition'

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -204,7 +204,7 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// we can't rely on exponential backoff because it will prolong the execution too much,
 			// instead we requeue on a fix interval.
 			msg := fmt.Sprintf("Dependencies do not meet ready condition, retrying in %s", r.requeueDependency.String())
-			log.Error(err, msg)
+			log.Info(msg)
 			r.event(ctx, kustomization, source.GetArtifact().Revision, events.EventSeverityInfo, msg, nil)
 			r.recordReadiness(ctx, kustomization)
 			return ctrl.Result{RequeueAfter: r.requeueDependency}, nil


### PR DESCRIPTION
Reduce the log level from error to info to match the level of the event.  The `kustomize-controller` pod's log has `error` message like:

`{"level":"error","ts":"2021-03-26T02:39:43.980Z","logger":"controller.kustomization","msg":"Dependencies do not meet ready condition, retrying in 30s","reconciler group":"kustomize.toolkit.fluxcd.io","reconciler kind":"Kustomization","name":"apps","namespace":"flux-system","error":"dependency 'flux-system/infrastructure' is not ready"}`

though the events / notifications written are at level `info`.

Context is discussion at https://github.com/fluxcd/flux2/discussions/1160#discussioncomment-580148