### PR TITLE
Refactor indexers to use high-order functions

### DIFF
--- a/controllers/kustomization_indexers.go
+++ b/controllers/kustomization_indexers.go
@@ -28,112 +28,63 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 )
 
-func (r *KustomizationReconciler) requestsForGitRepositoryRevisionChange(obj client.Object) []reconcile.Request {
-	repo, ok := obj.(*sourcev1.GitRepository)
-	if !ok {
-		panic(fmt.Sprintf("Expected a GitRepository but got a %T", obj))
-	}
-	// If we do not have an artifact, we have no requests to make
-	if repo.GetArtifact() == nil {
-		return nil
-	}
-
-	ctx := context.Background()
-	var list kustomizev1.KustomizationList
-	if err := r.List(ctx, &list, client.MatchingFields{
-		kustomizev1.GitRepositoryIndexKey: ObjectKey(obj).String(),
-	}); err != nil {
-		return nil
-	}
-	var dd []dependency.Dependent
-	for _, d := range list.Items {
-		// If the revision of the artifact equals to the last attempted revision,
-		// we should not make a request for this Kustomization
-		if repo.GetArtifact().Revision == d.Status.LastAttemptedRevision {
-			continue
+func (r *KustomizationReconciler) requestsForRevisionChangeOf(indexKey string) func(obj client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		repo, ok := obj.(interface {
+			GetArtifact() *sourcev1.Artifact
+		})
+		if !ok {
+			panic(fmt.Sprintf("Expected an object conformed with GetArtifact() method, but got a %T", obj))
 		}
-		dd = append(dd, d)
+		// If we do not have an artifact, we have no requests to make
+		if repo.GetArtifact() == nil {
+			return nil
+		}
+
+		ctx := context.Background()
+		var list kustomizev1.KustomizationList
+		if err := r.List(ctx, &list, client.MatchingFields{
+			indexKey: ObjectKey(obj).String(),
+		}); err != nil {
+			return nil
+		}
+		var dd []dependency.Dependent
+		for _, d := range list.Items {
+			// If the revision of the artifact equals to the last attempted revision,
+			// we should not make a request for this Kustomization
+			if repo.GetArtifact().Revision == d.Status.LastAttemptedRevision {
+				continue
+			}
+			dd = append(dd, d)
+		}
+		sorted, err := dependency.Sort(dd)
+		if err != nil {
+			return nil
+		}
+		reqs := make([]reconcile.Request, len(sorted), len(sorted))
+		for i := range sorted {
+			reqs[i].NamespacedName.Name = sorted[i].Name
+			reqs[i].NamespacedName.Namespace = sorted[i].Namespace
+		}
+		return reqs
 	}
-	sorted, err := dependency.Sort(dd)
-	if err != nil {
-		return nil
-	}
-	reqs := make([]reconcile.Request, len(sorted), len(sorted))
-	for i := range sorted {
-		reqs[i].NamespacedName.Name = sorted[i].Name
-		reqs[i].NamespacedName.Namespace = sorted[i].Namespace
-	}
-	return reqs
 }
 
-func (r *KustomizationReconciler) indexByGitRepository(o client.Object) []string {
-	k, ok := o.(*kustomizev1.Kustomization)
-	if !ok {
-		panic(fmt.Sprintf("Expected a Kustomization, got %T", o))
-	}
-
-	if k.Spec.SourceRef.Kind == sourcev1.GitRepositoryKind {
-		namespace := k.GetNamespace()
-		if k.Spec.SourceRef.Namespace != "" {
-			namespace = k.Spec.SourceRef.Namespace
+func (r *KustomizationReconciler) indexBy(kind string) func(o client.Object) []string {
+	return func(o client.Object) []string {
+		k, ok := o.(*kustomizev1.Kustomization)
+		if !ok {
+			panic(fmt.Sprintf("Expected a Kustomization, got %T", o))
 		}
-		return []string{fmt.Sprintf("%s/%s", namespace, k.Spec.SourceRef.Name)}
-	}
 
-	return nil
-}
+		if k.Spec.SourceRef.Kind == kind {
+			namespace := k.GetNamespace()
+			if k.Spec.SourceRef.Namespace != "" {
+				namespace = k.Spec.SourceRef.Namespace
+			}
+			return []string{fmt.Sprintf("%s/%s", namespace, k.Spec.SourceRef.Name)}
+		}
 
-func (r *KustomizationReconciler) requestsForBucketRevisionChange(obj client.Object) []reconcile.Request {
-	bucket, ok := obj.(*sourcev1.Bucket)
-	if !ok {
-		panic(fmt.Sprintf("Expected a Bucket but got a %T", obj))
-	}
-	// If we do not have an artifact, we have no requests to make
-	if bucket.GetArtifact() == nil {
 		return nil
 	}
-
-	ctx := context.Background()
-	var list kustomizev1.KustomizationList
-	if err := r.List(ctx, &list, client.MatchingFields{
-		kustomizev1.BucketIndexKey: ObjectKey(obj).String(),
-	}); err != nil {
-		return nil
-	}
-	var dd []dependency.Dependent
-	for _, d := range list.Items {
-		// If the revision of the artifact equals to the last attempted revision,
-		// we should not make a request for this Kustomization
-		if bucket.GetArtifact().Revision == d.Status.LastAttemptedRevision {
-			continue
-		}
-		dd = append(dd, d)
-	}
-	sorted, err := dependency.Sort(dd)
-	if err != nil {
-		return nil
-	}
-	reqs := make([]reconcile.Request, len(sorted), len(sorted))
-	for i := range sorted {
-		reqs[i].NamespacedName.Name = sorted[i].Name
-		reqs[i].NamespacedName.Namespace = sorted[i].Namespace
-	}
-	return reqs
-}
-
-func (r *KustomizationReconciler) indexByBucket(o client.Object) []string {
-	k, ok := o.(*kustomizev1.Kustomization)
-	if !ok {
-		panic(fmt.Sprintf("Expected a Kustomization, got %T", o))
-	}
-
-	if k.Spec.SourceRef.Kind == sourcev1.BucketKind {
-		namespace := k.GetNamespace()
-		if k.Spec.SourceRef.Namespace != "" {
-			namespace = k.Spec.SourceRef.Namespace
-		}
-		return []string{fmt.Sprintf("%s/%s", namespace, k.Spec.SourceRef.Name)}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This PR refactored indexers by using high-order functions to replace redundant codes by half without altering the semantics.