### PR TITLE
Extracting validation error from apply server dry run output

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -57,10 +57,13 @@ func parseApplyError(in []byte) string {
 		if line != "" &&
 			!strings.HasSuffix(line, "created") &&
 			!strings.HasSuffix(line, "created (dry run)") &&
+			!strings.HasSuffix(line, "created (server dry run)") &&
 			!strings.HasSuffix(line, "configured") &&
 			!strings.HasSuffix(line, "configured (dry run)") &&
+			!strings.HasSuffix(line, "configured (server dry run)") &&
 			!strings.HasSuffix(line, "unchanged") &&
-			!strings.HasSuffix(line, "unchanged (dry run)") {
+			!strings.HasSuffix(line, "unchanged (dry run)") &&
+			!strings.HasSuffix(line, "unchanged (server dry run)") {
 			errors += line + "\n"
 		}
 	}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -5,41 +5,52 @@ import (
 	"testing"
 )
 
-func Test_parseApplyError(t *testing.T) {
-	filtered := parseApplyError([]byte(`
+func TestParseApplyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       []byte
+		filtered string
+	}{
+		{
+			"apply",
+			[]byte(`
 gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged
 ingressroute.traefik.containo.us/flux-receiver configured
 service/notification-controller created
-The Service "webhook-receiver" is invalid: spec.clusterIP: Invalid value: "10.200.133.61": field is immutable`))
-	filtered = strings.TrimSpace(filtered)
-	numLines := len(strings.Split(filtered, "\n"))
-	if numLines != 1 {
-		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
-	}
-}
-
-func Test_parseApplyError_dryRun(t *testing.T) {
-	filtered := parseApplyError([]byte(`
+The Service "webhook-receiver" is invalid: spec.clusterIP: Invalid value: "10.200.133.61": field is immutable
+`),
+			`The Service "webhook-receiver" is invalid: spec.clusterIP: Invalid value: "10.200.133.61": field is immutable`,
+		},
+		{
+			"client dry-run",
+			[]byte(`
 gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged (dry run)
 ingressroute.traefik.containo.us/flux-receiver configured (dry run)
 service/notification-controller created (dry run)
-error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`))
-	filtered = strings.TrimSpace(filtered)
-	numLines := len(strings.Split(filtered, "\n"))
-	if numLines != 1 {
-		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
-	}
-}
-
-func Test_parseApplyError_serverDryRun(t *testing.T) {
-	filtered := parseApplyError([]byte(`
+error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container
+`),
+			`error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`,
+		},
+		{
+			"server dry-run",
+			[]byte(`
 gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged (server dry run)
 ingressroute.traefik.containo.us/flux-receiver configured (server dry run)
 service/notification-controller created (server dry run)
-error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`))
-	filtered = strings.TrimSpace(filtered)
-	numLines := len(strings.Split(filtered, "\n"))
-	if numLines != 1 {
-		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
+error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container
+`),
+			`error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := parseApplyError(tt.in)
+			filtered = strings.TrimSpace(filtered)
+
+			if tt.filtered != filtered {
+				t.Errorf("expected %q, but actual %q", tt.filtered, filtered)
+			}
+		})
 	}
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -30,3 +30,16 @@ error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Cont
 		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
 	}
 }
+
+func Test_parseApplyError_serverDryRun(t *testing.T) {
+	filtered := parseApplyError([]byte(`
+gitrepository.source.toolkit.fluxcd.io/flux-workspaces unchanged (server dry run)
+ingressroute.traefik.containo.us/flux-receiver configured (server dry run)
+service/notification-controller created (server dry run)
+error: error validating data: unknown field "ima  ge" in io.k8s.api.core.v1.Container`))
+	filtered = strings.TrimSpace(filtered)
+	numLines := len(strings.Split(filtered, "\n"))
+	if numLines != 1 {
+		t.Errorf("Should filter out all but one line from the error output, but got %d lines", numLines)
+	}
+}


### PR DESCRIPTION
In addition to client dry-run, I also improve the server dry-run case to reduce verbose output and only print errors.

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.4", GitCommit:"e87da0bd6e03ec3fea7933c4b5263d151aafd07c", GitTreeState:"clean", BuildDate:"2021-02-18T16:12:00Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-13T13:20:00Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
$ kubectl create deploy nginx --image nginx --dry-run=client -o yaml | kubectl apply -f- --dry-run=server
deployment.apps/nginx created (server dry run)
```

ref/ https://github.com/fluxcd/kustomize-controller/issues/277