### PR TITLE
Fix validation and application timeout handling

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -611,8 +611,8 @@ func (r *KustomizationReconciler) validate(ctx context.Context, kustomization ku
 	command := exec.CommandContext(applyCtx, "/bin/sh", "-c", cmd)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("validation timeout: %w", err)
+		if errors.Is(applyCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("validation timeout: %w", applyCtx.Err())
 		}
 		return fmt.Errorf("validation failed: %s", parseApplyError(output))
 	}
@@ -651,8 +651,8 @@ func (r *KustomizationReconciler) apply(ctx context.Context, kustomization kusto
 	command := exec.CommandContext(applyCtx, "/bin/sh", "-c", cmd)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return "", fmt.Errorf("apply timeout: %w", err)
+		if errors.Is(applyCtx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("apply timeout: %w", applyCtx.Err())
 		}
 
 		if string(output) == "" {


### PR DESCRIPTION
`err` returned from `command.CombinedOutput()` is an error of the command execution, not an error of the context.
To determine if the context was canceled, we should check out `context.Err()`.

Signed-off-by: Hidehito Yabuuchi <hdht.ybuc@gmail.com>