### PR TITLE
Add Checksum Annotation as Transformer to Kustomization

### DIFF
--- a/controllers/kustomization_gc.go
+++ b/controllers/kustomization_gc.go
@@ -152,6 +152,12 @@ func (kgc *KustomizeGarbageCollector) matchingLabels(name, namespace string) cli
 	return selectorLabels(name, namespace)
 }
 
+func checksumAnnotation(checksum string) map[string]string {
+	return map[string]string{
+		fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group): checksum,
+	}
+}
+
 func gcLabels(name, namespace, checksum string) map[string]string {
 	return map[string]string{
 		fmt.Sprintf("%s/name", kustomizev1.GroupVersion.Group):      name,


### PR DESCRIPTION
To avoid always adding this to labels (and to not break current users), the proposed solution is to add an AnnotationTransformer to add the checksum as an annotation to track stale resources deployed by Kustomization