### PR TITLE
Support decrypting any file format in secret generator

### DIFF
--- a/controllers/kustomization_controller_sops_test.go
+++ b/controllers/kustomization_controller_sops_test.go
@@ -185,6 +185,10 @@ var _ = Describe("KustomizationReconciler", func() {
 			var daySecret corev1.Secret
 			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: "sops-day", Namespace: namespace.Name}, &daySecret)).To(Succeed())
 			Expect(string(daySecret.Data["secret"])).To(Equal("day=Tuesday\n"))
+
+			var encodedSecret corev1.Secret
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: "sops-month", Namespace: namespace.Name}, &encodedSecret)).To(Succeed())
+			Expect(string(encodedSecret.Data["month.yaml"])).To(Equal("month: May\n"))
 		})
 	})
 })

--- a/controllers/kustomization_decryptor.go
+++ b/controllers/kustomization_decryptor.go
@@ -157,9 +157,9 @@ func (kd *KustomizeDecryptor) Decrypt(res *resource.Resource) (*resource.Resourc
 						return nil, fmt.Errorf("AES decrypt: %w", err)
 					}
 
-					binaryStore := common.StoreForFormat(formats.Binary)
+					outputStore := common.DefaultStoreForPath(key)
 
-					out, err := binaryStore.EmitPlainFile(tree.Branches)
+					out, err := outputStore.EmitPlainFile(tree.Branches)
 					if err != nil {
 						return nil, fmt.Errorf("EmitPlainFile: %w", err)
 					}

--- a/controllers/testdata/sops/.sops.yaml
+++ b/controllers/testdata/sops/.sops.yaml
@@ -4,6 +4,8 @@ creation_rules:
   - path_regex: \.age.yaml$
     encrypted_regex: ^(data|stringData)$
     age: age1l44xcng8dqj32nlv6d930qvvrny05hglzcv9qpc7kxjc6902ma4qufys29
+  - path_regex: month.yaml$
+    pgp: 35C1A64CD7FC0AB6EB66756B2445463C3234ECE1
   # fallback to PGP
   - encrypted_regex: ^(data|stringData)$
     pgp: 35C1A64CD7FC0AB6EB66756B2445463C3234ECE1

--- a/controllers/testdata/sops/month/kustomization.yaml
+++ b/controllers/testdata/sops/month/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+- name: sops-month
+  files:
+  - month.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/controllers/testdata/sops/month/month.yaml
+++ b/controllers/testdata/sops/month/month.yaml
@@ -1,0 +1,32 @@
+month: ENC[AES256_GCM,data:9e+R,iv:EzJxah6sCY2D9L76l/CuVq6qVq2ncJDYphm9gXE/ZgM=,tag:r82agynzHp/aOTVo6Iu9wg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-05-31T11:27:34Z"
+    mac: ENC[AES256_GCM,data:BV/jKqSzKr2sq/yA4HToFseOWOB04cYo+54Dby/Jp4ZuVwxNt1i02zncsvWyQZK5WFcvK47brvzN6fWJyyf5WnX+XISbuUDGMWjqNG/te3YKEY4ZqJUopDF/AxDZDkUC5KdnIln6RZqtHuJH18J35kakWFrg1YOJtI28ZVK5yBM=,iv:T6JJkYbfqpUz2AClToZtSsuVbUXcPD5nqaUhJJdH6Uc=,tag:jvmH8iyfivoGIt1k+Uodrg==,type:str]
+    pgp:
+        - created_at: "2021-05-31T11:27:34Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA90SOJihaAjLAQ/9HYs2HyaYL9dOj8zIAr3JzqEFHlMX59Vw8kj9KxBQJXYQ
+            N3mE/HHQVBWk/36Pq/14n0Eals8GwivDDiJmovfeRASmb0/LnGQDzMkDGEJvyu7N
+            Q69rBjzVWbmMPgI0vQb0zTBRcUW+LnSijkv+H5mxuFnnZd8N3UeFLHX2oKNeA7O3
+            pYjjK8vr6KaXJqYfH+bFs29cnk0+xZiThr21cz40yFZD7ynns4xjdVtqI5bvGk/F
+            bDW7oGgJe+q/9OHKJaVESLrcZMe2lLxA7x821ssq6BlNzv9DHTc7PloVNepsze6d
+            MBTgzAZoH04ENQSiL9qo24AVGaFhUXak7MslxE8nhjFJD6sfb0Q/LtlhOSpDw7NR
+            gugPzQuQLGN9U54id0bql8CBi58g0wdxjo6kDlMYTEd9CZbugfM1pR1imknlgPLi
+            7ODDrWTTxnZm4+hZRj7EjMGlRshavPgZ/rgT1tTnjNw9c+llgCWW8Ei8JOEvA86M
+            DwsPzodesMO56yf3MJPAgakCapTH9VMad+E63yUMsNAX6+otrjgssvxg3j8KnjPp
+            Z7593P7RGYrRR+YwEi5nTHmDL1H80vP6pNnBGd7wLa3TLzypkDiZSKY6vq6vSIwd
+            QOpLX3VC2X53mtWmNm7oWxKLX3hKPrjTqBYE0EDK7Yc0q8rj++ygntOekI+WSm/S
+            XAG4Ufue6i2MTvnZmK/Byt+E/zT4jRmjRQImGekHB+rLYfM3Z85i6ExH4OCCWNqC
+            rg4DqrWTS8Nvt2PE5UC3Phqe51D4/ZrQPVPkFQftgQl44xECv4X8rI7RTux6
+            =HE0m
+            -----END PGP MESSAGE-----
+          fp: 35C1A64CD7FC0AB6EB66756B2445463C3234ECE1
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1


### PR DESCRIPTION
This is an extension of #329, which added the support for decrypting files passed to the secret generator. The previous implementation only supported encrypted binary types, but failed when the content was a JSON or a YAML, with the message `EmitPlainFile: No binary data found in tree`.

This small change detects the format using the key/filename in the secret.