### PR TITLE
Move the GC checksum from labels to annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Prerequisites:
 * go >= 1.13
 * kubebuilder >= 2.3
 * kustomize >= 3.1
+* kubectl >= 1.21
 
 You can run the unit tests by simply doing
 

--- a/controllers/kustomization_controller_gc_test.go
+++ b/controllers/kustomization_controller_gc_test.go
@@ -144,7 +144,7 @@ data:
 
 			var configMap corev1.ConfigMap
 			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: "first", Namespace: namespace.Name}, &configMap)).To(Succeed())
-			Expect(configMap.Labels[fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group)]).NotTo(BeEmpty())
+			Expect(configMap.Annotations[fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group)]).NotTo(BeEmpty())
 
 			manifest.Body = configMapManifest("second")
 			artifact, err = artifactServer.ArtifactFromFiles([]testserver.File{manifest})
@@ -163,7 +163,7 @@ data:
 			err = k8sClient.Get(context.Background(), client.ObjectKey{Name: "first", Namespace: namespace.Name}, &configMap)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: "second", Namespace: namespace.Name}, &configMap)).To(Succeed())
-			Expect(configMap.Labels[fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group)]).NotTo(BeEmpty())
+			Expect(configMap.Annotations[fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group)]).NotTo(BeEmpty())
 
 			Expect(k8sClient.Delete(context.Background(), kustomization)).To(Succeed())
 			Eventually(func() bool {

--- a/controllers/kustomization_controller_test.go
+++ b/controllers/kustomization_controller_test.go
@@ -360,6 +360,92 @@ spec:
 				Expect(deployment.Spec.Selector.MatchLabels["app"]).To(Equal("v2"))
 			})
 		})
+
+		Describe("Kustomization resource annotation", func() {
+			deploymentManifest := func(namespace string) string {
+				return fmt.Sprintf(`---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: test-deployment
+  template:
+    metadata:
+      labels:
+        app: test-deployment
+    spec:
+      containers:
+      - name: test
+        image: podinfo
+`,
+					namespace)
+			}
+
+			It("should have no annotation when if prune is false", func() {
+				manifests := []testserver.File{
+					{
+						Name: "deployment.yaml",
+						Body: deploymentManifest(namespace.Name),
+					},
+				}
+				artifact, err := httpServer.ArtifactFromFiles(manifests)
+				Expect(err).NotTo(HaveOccurred())
+
+				url := fmt.Sprintf("%s/%s", httpServer.URL(), artifact)
+
+				repositoryName := types.NamespacedName{
+					Name:      fmt.Sprintf("%s", randStringRunes(5)),
+					Namespace: namespace.Name,
+				}
+				repository := readyGitRepository(repositoryName, url, "v1", "")
+				Expect(k8sClient.Create(context.Background(), repository)).To(Succeed())
+				Expect(k8sClient.Status().Update(context.Background(), repository)).To(Succeed())
+				defer k8sClient.Delete(context.Background(), repository)
+
+				kName := types.NamespacedName{
+					Name:      fmt.Sprintf("%s", randStringRunes(5)),
+					Namespace: namespace.Name,
+				}
+				k := &kustomizev1.Kustomization{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kName.Name,
+						Namespace: kName.Namespace,
+					},
+					Spec: kustomizev1.KustomizationSpec{
+						KubeConfig: kubeconfig,
+						Interval:   metav1.Duration{Duration: reconciliationInterval},
+						Path:       "./",
+						Prune:      false,
+						SourceRef: kustomizev1.CrossNamespaceSourceReference{
+							Kind: sourcev1.GitRepositoryKind,
+							Name: repository.Name,
+						},
+						Suspend:    false,
+						Timeout:    &metav1.Duration{Duration: 60 * time.Second},
+						Validation: "client",
+						Force:      true,
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), k)).To(Succeed())
+				defer k8sClient.Delete(context.Background(), k)
+
+				got := &kustomizev1.Kustomization{}
+				Eventually(func() bool {
+					_ = k8sClient.Get(context.Background(), kName, got)
+					c := apimeta.FindStatusCondition(got.Status.Conditions, meta.ReadyCondition)
+					return c != nil && c.Reason == meta.ReconciliationSucceededReason
+				}, timeout, interval).Should(BeTrue())
+				Expect(got.Status.LastAppliedRevision).To(Equal("v1"))
+
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-deployment", Namespace: namespace.Name}, deployment)).To(Succeed())
+				Expect(deployment.Annotations[fmt.Sprintf("%s/checksum", kustomizev1.GroupVersion.Group)]).To(BeEmpty())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
This PR moves the `kustomize.toolkit.fluxcd.io/checksum` from labels to annotations. This should fix any conflicts with 3rd party controllers like Stash (fix: #315) that are copying the labels from their custom resources to generated objects.

