### PR TITLE
Add support for in-line generic patches to Flux Kustomization API

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,7 +3,7 @@ module github.com/fluxcd/kustomize-controller/api
 go 1.16
 
 require (
-	github.com/fluxcd/pkg/apis/kustomize v0.1.0
+	github.com/fluxcd/pkg/apis/kustomize v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.10.0
 	github.com/fluxcd/pkg/runtime v0.12.0
 	k8s.io/apiextensions-apiserver v0.21.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -90,8 +90,8 @@ github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMi
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fluxcd/pkg/apis/kustomize v0.1.0 h1:sauL+KHmZ0zV2ZgpsLMyDzCQudBTtaFzSys+rXn9g9w=
-github.com/fluxcd/pkg/apis/kustomize v0.1.0/go.mod h1:gEl+W5cVykCC3RfrCaqe+Pz+j4lKl2aeR4dxsom/zII=
+github.com/fluxcd/pkg/apis/kustomize v0.2.0 h1:jhu2QHvs+j3Zo9rR6w8hkO3LSC6h3M37zY5ejufOmxY=
+github.com/fluxcd/pkg/apis/kustomize v0.2.0/go.mod h1:gEl+W5cVykCC3RfrCaqe+Pz+j4lKl2aeR4dxsom/zII=
 github.com/fluxcd/pkg/apis/meta v0.10.0 h1:N7wVGHC1cyPdT87hrDC7UwCwRwnZdQM46PBSLjG2rlE=
 github.com/fluxcd/pkg/apis/meta v0.10.0/go.mod h1:CW9X9ijMTpNe7BwnokiUOrLl/h13miwVr/3abEQLbKE=
 github.com/fluxcd/pkg/runtime v0.12.0 h1:BPZZ8bBkimpqGAPXqOf3LTaw+tcw6HgbWyCuzbbsJGs=

--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -83,6 +83,10 @@ type KustomizationSpec struct {
 	// +optional
 	HealthChecks []meta.NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
+	// Patches (also called overlays), defined as inline YAML objects.
+	// +optional
+	Patches []kustomize.Patch `json:"patches,omitempty"`
+
 	// Strategic merge patches, defined as inline YAML objects.
 	// +optional
 	PatchesStrategicMerge []apiextensionsv1.JSON `json:"patchesStrategicMerge,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *KustomizationSpec) DeepCopyInto(out *KustomizationSpec) {
 		*out = make([]meta.NamespacedObjectKindReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.Patches != nil {
+		in, out := &in.Patches, &out.Patches
+		*out = make([]kustomize.Patch, len(*in))
+		copy(*out, *in)
+	}
 	if in.PatchesStrategicMerge != nil {
 		in, out := &in.PatchesStrategicMerge, &out.PatchesStrategicMerge
 		*out = make([]apiextensionsv1.JSON, len(*in))

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -142,6 +142,41 @@ spec:
                     - name
                     type: object
                 type: object
+              patches:
+                description: Patches (also called overlays), defined as inline YAML objects.
+                items:
+                  description: Patch contains either a StrategicMerge or a JSON6902 patch, either a file or inline, and the target the patch should be applied to.
+                  properties:
+                    patch:
+                      description: Patch contains the JSON6902 patch document with an array of operation objects.
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch document should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: Group is the API group to select resources from. Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: Kind of the API Group to select resources from. Together with Group and Version it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: Version of the API Group to select resources from. Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                  type: object
+                type: array
               patchesJson6902:
                 description: JSON 6902 patches, defined as inline YAML objects.
                 items:

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -104,6 +104,13 @@ func (kg *KustomizeGenerator) WriteFile(ctx context.Context, dirPath string) (st
 		kus.Namespace = kg.kustomization.Spec.TargetNamespace
 	}
 
+	for _, m := range kg.kustomization.Spec.Patches {
+		kus.Patches = append(kus.Patches, kustypes.Patch{
+			Patch:  m.Patch,
+			Target: adaptSelector(&m.Target),
+		})
+	}
+
 	for _, m := range kg.kustomization.Spec.PatchesStrategicMerge {
 		kus.PatchesStrategicMerge = append(kus.PatchesStrategicMerge, kustypes.PatchStrategicMerge(m.Raw))
 	}

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -198,6 +198,20 @@ bool
 </tr>
 <tr>
 <td>
+<code>patches</code><br>
+<em>
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/kustomize#Patch">
+[]github.com/fluxcd/pkg/apis/kustomize.Patch
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Patches (also called overlays), defined as inline YAML objects.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>patchesStrategicMerge</code><br>
 <em>
 <a href="https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1?tab=doc#JSON">
@@ -653,6 +667,20 @@ bool
 <td>
 <em>(Optional)</em>
 <p>A list of resources to be included in the health assessment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>patches</code><br>
+<em>
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/kustomize#Patch">
+[]github.com/fluxcd/pkg/apis/kustomize.Patch
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Patches (also called overlays), defined as inline YAML objects.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -598,14 +598,15 @@ The Kustomization has a set of fields to extend and/or override the Kustomize
 patches and namespace on all the Kubernetes objects reconciled by the resource,
 offering support for the following Kustomize directives:
 
-- [namespace](https://kubectl.docs.kubernetes.io/references/kustomize/namespace/)
+- [namespace](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/namespace/)
+- [patches](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/)
 - [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/)
-- [patchesJson6902](https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/)
-- [images](https://kubectl.docs.kubernetes.io/references/kustomize/images/)
+- [patchesJson6902](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/)
+- [images](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/)
 
 ### Target namespace
 
-To configure the [Kustomize `namespace`](https://kubectl.docs.kubernetes.io/references/kustomize/namespace/)
+To configure the [Kustomize `namespace`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/namespace/)
 and overwrite the namespace of all the Kubernetes objects reconciled by the `Kustomization`,
 `spec.targetNamespace` can be defined:
 
@@ -622,9 +623,35 @@ spec:
 
 The `targetNamespace` is expected to exist.
 
+### Patches
+
+To add [Kustomize `patches` entries](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/)
+to the configuration, and patch resources using either a [strategic merge](https://kubectl.docs.kubernetes.io/references/kustomize/glossary#patchstrategicmerge) 
+patch or a [JSON](https://kubectl.docs.kubernetes.io/references/kustomize/glossary#patchjson6902) patch,
+`spec.patches` items must contain a `target` selector and a `patch` document.
+The patch can target a single resource or multiple resources
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  # ...omitted for brevity
+  patches:
+    - patch: |-
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: not-used
+          labels:
+            app.kubernetes.io/part-of: test-app
+```
+
 ### Strategic Merge patches
 
-To add [Kustomize `patchesStrategicMerge` entries](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/)
+To add [Kustomize `patchesStrategicMerge` entries](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/)
 to the configuration, `spec.patchesStrategicMerge` can be defined with a list
 of strategic merge patches in YAML format:
 
@@ -649,7 +676,7 @@ spec:
 
 ### JSON 6902 patches
 
-To add [Kustomize `patchesJson6902` entries](https://kubectl.docs.kubernetes.io/references/kustomize/patchesjson6902/)
+To add [Kustomize `patchesJson6902` entries](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/)
 to the configuration, and patch resources using the [JSON 6902 standard](https://tools.ietf.org/html/rfc6902),
 `spec.patchesJson6902`, the items must contain a `target` selector and JSON 6902
 `patch` document:
@@ -675,7 +702,7 @@ spec:
 
 ### Images
 
-To add [Kustomize `images` entries](https://kubectl.docs.kubernetes.io/references/kustomize/images/)
+To add [Kustomize `images` entries](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/)
 to the configuration, and overwrite the name, tag or digest of container images
 without creating patches, `spec.images` can be defined:
 

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -647,6 +647,8 @@ spec:
           name: not-used
           labels:
             app.kubernetes.io/part-of: test-app
+      target:
+        labelSelector: "app=podinfo"
 ```
 
 ### Strategic Merge patches

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603
 	github.com/fluxcd/kustomize-controller/api v0.12.2
-	github.com/fluxcd/pkg/apis/kustomize v0.1.0
+	github.com/fluxcd/pkg/apis/kustomize v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.10.0
 	github.com/fluxcd/pkg/runtime v0.12.0
 	github.com/fluxcd/pkg/testserver v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/fluxcd/pkg/apis/kustomize v0.1.0 h1:sauL+KHmZ0zV2ZgpsLMyDzCQudBTtaFzSys+rXn9g9w=
-github.com/fluxcd/pkg/apis/kustomize v0.1.0/go.mod h1:gEl+W5cVykCC3RfrCaqe+Pz+j4lKl2aeR4dxsom/zII=
+github.com/fluxcd/pkg/apis/kustomize v0.2.0 h1:jhu2QHvs+j3Zo9rR6w8hkO3LSC6h3M37zY5ejufOmxY=
+github.com/fluxcd/pkg/apis/kustomize v0.2.0/go.mod h1:gEl+W5cVykCC3RfrCaqe+Pz+j4lKl2aeR4dxsom/zII=
 github.com/fluxcd/pkg/apis/meta v0.10.0 h1:N7wVGHC1cyPdT87hrDC7UwCwRwnZdQM46PBSLjG2rlE=
 github.com/fluxcd/pkg/apis/meta v0.10.0/go.mod h1:CW9X9ijMTpNe7BwnokiUOrLl/h13miwVr/3abEQLbKE=
 github.com/fluxcd/pkg/runtime v0.12.0 h1:BPZZ8bBkimpqGAPXqOf3LTaw+tcw6HgbWyCuzbbsJGs=


### PR DESCRIPTION
The `patchesJson6902` or `patchesStrategicMerge` fields in a Kustomize resource only allow patching single named resources. In order to patch multiple resources with a single patch, the generic `patches` field need to be used.

This PR implement the generic `patches` at the kustomize.toolkit.fluxcd.io/v1beta1/Kustomization level to unlock that feature.

One use case, would be for instance to override all path of all Kustomization at once without having to patch then one by one:
```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
kind: Kustomization
metadata:
  name: podinfo
  namespace: flux-system
spec:
  # ...omitted for brevity
  patches:
    - patch: |-
        - op: replace
          path: /spec/path
          value: ./deploy/lab/
      target:
        group: kustomize.toolkit.fluxcd.io
        version: v1beta1
        kind: Kustomization
```

The field `options` from the original Kustomization is **not implemented**
```
  options:
    allowNameChange: true
    allowKindChange: true
```

This PR can only be merge if [pkg PR #109](https://github.com/fluxcd/pkg/pull/109) is accepted.