### PR TITLE
Make the kubeconfig secrets compatible with SOPS

### DIFF
--- a/controllers/kustomization_controller_test.go
+++ b/controllers/kustomization_controller_test.go
@@ -438,7 +438,7 @@ func kubeConfigSecret() (*corev1.Secret, error) {
 			Name: "kubeconfig",
 		},
 		Data: map[string][]byte{
-			"value": kubeConfig,
+			"value.yaml": kubeConfig,
 		},
 	}, nil
 }

--- a/controllers/kustomization_impersonation.go
+++ b/controllers/kustomization_impersonation.go
@@ -195,8 +195,15 @@ func (ki *KustomizeImpersonation) getKubeConfig(ctx context.Context) ([]byte, er
 		return nil, fmt.Errorf("unable to read KubeConfig secret '%s' error: %w", secretName.String(), err)
 	}
 
-	kubeConfig, ok := secret.Data["value"]
-	if !ok {
+	var kubeConfig []byte
+	for k, _ := range secret.Data {
+		if k == "value" || k == "value.yaml" {
+			kubeConfig = secret.Data[k]
+			break
+		}
+	}
+
+	if len(kubeConfig) == 0 {
 		return nil, fmt.Errorf("KubeConfig secret '%s' doesn't contain a 'value' key ", secretName.String())
 	}
 

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -845,11 +845,10 @@ If the `kubeConfig` field is set, objects will be applied, health-checked, prune
 cluster specified in that KubeConfig instead of using the in-cluster ServiceAccount.
 
 The secret defined in the `kubeConfig.SecretRef` must exist in the same namespace as the Kustomization.
-On every reconciliation, the KubeConfig bytes will be loaded from the `values` key of the secret's data, and
-the secret can thus be regularly updated if cluster-access-tokens have to rotate due to expiration.
+On every reconciliation, the KubeConfig bytes will be loaded from the `value` or `value.yaml` key of the secret's data,
+and the secret can thus be regularly updated if cluster-access-tokens have to rotate due to expiration.
 
-This composes well with Cluster API bootstrap providers such as CAPBK (kubeadm) as well as the CAPA (AWS) EKS
-integration.
+This composes well with Cluster API bootstrap providers such as CAPBK (kubeadm), CAPA (AWS) and others.
 
 To reconcile a Kustomization to a CAPI controlled cluster, put the `Kustomization` in the same namespace as your
 `Cluster` object, and set the `kubeConfig.secretRef.name` to `<cluster-name>-kubeconfig`:
@@ -908,7 +907,7 @@ cluster where kustomize-controller is running e.g.:
 
 ```sh
 kubectl create secret generic prod-kubeconfig \
-    --from-file=value=./kubeconfig
+    --from-file=value.yaml=./kubeconfig
 ```
 
 > **Note** that the KubeConfig should be self-contained and not rely on binaries, environment,


### PR DESCRIPTION
Add `values.yaml` to the supported kubeconfig secret key names in order for SOPS to correctly detect the storage format based on the file extension.

Fix: #399 

~~TODO: This must be ported to helm-controller before the next flux release.~~