### PR TITLE
Fix inventory panic for v1beta1 objects

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -757,7 +757,10 @@ func (r *KustomizationReconciler) prune(ctx context.Context, manager *ssa.Resour
 
 func (r *KustomizationReconciler) finalize(ctx context.Context, kustomization kustomizev1.Kustomization) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
-	if kustomization.Spec.Prune && !kustomization.Spec.Suspend {
+	if kustomization.Spec.Prune &&
+		!kustomization.Spec.Suspend &&
+		kustomization.Status.Inventory != nil &&
+		kustomization.Status.Inventory.Entries != nil {
 		objects, err := ListObjectsInInventory(kustomization.Status.Inventory)
 
 		impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, "")

--- a/controllers/kustomization_inventory.go
+++ b/controllers/kustomization_inventory.go
@@ -57,6 +57,10 @@ func AddObjectsToInventory(inv *kustomizev1.ResourceInventory, objects []*unstru
 func ListObjectsInInventory(inv *kustomizev1.ResourceInventory) ([]*unstructured.Unstructured, error) {
 	objects := make([]*unstructured.Unstructured, 0)
 
+	if inv.Entries == nil {
+		return objects, nil
+	}
+
 	for _, entry := range inv.Entries {
 		objMetadata, err := object.ParseObjMetadata(entry.ID)
 		if err != nil {


### PR DESCRIPTION
Fix panic observed in flux2 e2e tests when an older Flux CLI version is used to create v1beta1 objects.