### PR TITLE
Fix SSA upstream bugs for Kubernetes < 1.22

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -651,6 +651,9 @@ func (r *KustomizationReconciler) apply(ctx context.Context, manager *ssa.Resour
 	// sort by kind, validate and apply all the others objects
 	sort.Sort(ssa.SortableUnstructureds(stageTwo))
 	if len(stageTwo) > 0 {
+		if err := ssa.SetNativeKindsDefaults(stageTwo); err != nil {
+			return false, err
+		}
 		changeSet, err := manager.ApplyAll(ctx, stageTwo, kustomization.Spec.Force)
 		if err != nil {
 			return false, fmt.Errorf("%w\n%s", err, changeSetLog.String())

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.10.1
 	github.com/fluxcd/pkg/runtime v0.12.2
-	github.com/fluxcd/pkg/ssa v0.0.2
+	github.com/fluxcd/pkg/ssa v0.0.3
 	github.com/fluxcd/pkg/testserver v0.1.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/source-controller/api v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.1/go.mod h1:yUblM2vg+X8TE3A2VvJfdhkGmg+uqB
 github.com/fluxcd/pkg/runtime v0.12.0/go.mod h1:EyaTR2TOYcjL5U//C4yH3bt2tvTgIOSXpVRbWxUn/C4=
 github.com/fluxcd/pkg/runtime v0.12.2 h1:4iOpx2j/w15kNemDOnZrF6ugJ/rhSmRu7aI+xn23+BI=
 github.com/fluxcd/pkg/runtime v0.12.2/go.mod h1:tuWdqpWPhgjQvYrSnojdZ4plyU8DRU1NDzsfOhnzl2g=
-github.com/fluxcd/pkg/ssa v0.0.2 h1:ATIPgo7YxPfI2anLkBYDavbtTlpuvvHgqk8dKxthH4Y=
-github.com/fluxcd/pkg/ssa v0.0.2/go.mod h1:QisgqnXXnHKNfdnrpJ3wQrwuto111mvdNcKkfe9Cwvk=
+github.com/fluxcd/pkg/ssa v0.0.3 h1:5s/dZIaJGtI/46w5VRmr5sy/jNJGpxPnSad8oSzAbkc=
+github.com/fluxcd/pkg/ssa v0.0.3/go.mod h1:B/6V2gF3zq3P6EstM/qTmOEUf3YgOh1ybFfAAmG4Shw=
 github.com/fluxcd/pkg/testserver v0.1.0 h1:nOYgM1HYFZNNSUFykuWDmrsxj4jQxUCvmLHWOQeqmyA=
 github.com/fluxcd/pkg/testserver v0.1.0/go.mod h1:fvt8BHhXw6c1+CLw1QFZxcQprlcXzsrL4rzXaiGM+Iw=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=


### PR DESCRIPTION
Bump fluxcd/pkg/ssa to v0.0.3, workarounds for server-side apply upstream bugs affecting Kubernetes < 1.22

- ContainerPort missing default TCP proto: https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
- ServicePort missing default TCP proto: https://github.com/kubernetes/kubernetes/pull/98576
- PodSpec resources missing int to string conversion for e.g. 'cpu: 2'

Ref: https://github.com/fluxcd/flux2/issues/1917