### PR TITLE
Fix drift detection in Secrets and ConfigMaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.10.1
 	github.com/fluxcd/pkg/runtime v0.12.2
-	github.com/fluxcd/pkg/ssa v0.0.3
+	github.com/fluxcd/pkg/ssa v0.0.5
 	github.com/fluxcd/pkg/testserver v0.1.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/source-controller/api v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.1/go.mod h1:yUblM2vg+X8TE3A2VvJfdhkGmg+uqB
 github.com/fluxcd/pkg/runtime v0.12.0/go.mod h1:EyaTR2TOYcjL5U//C4yH3bt2tvTgIOSXpVRbWxUn/C4=
 github.com/fluxcd/pkg/runtime v0.12.2 h1:4iOpx2j/w15kNemDOnZrF6ugJ/rhSmRu7aI+xn23+BI=
 github.com/fluxcd/pkg/runtime v0.12.2/go.mod h1:tuWdqpWPhgjQvYrSnojdZ4plyU8DRU1NDzsfOhnzl2g=
-github.com/fluxcd/pkg/ssa v0.0.3 h1:5s/dZIaJGtI/46w5VRmr5sy/jNJGpxPnSad8oSzAbkc=
-github.com/fluxcd/pkg/ssa v0.0.3/go.mod h1:B/6V2gF3zq3P6EstM/qTmOEUf3YgOh1ybFfAAmG4Shw=
+github.com/fluxcd/pkg/ssa v0.0.5 h1:WA8ShFeRTOLa8A1QZMyzIPygeMmHufkJhs1IpHEwX5w=
+github.com/fluxcd/pkg/ssa v0.0.5/go.mod h1:B/6V2gF3zq3P6EstM/qTmOEUf3YgOh1ybFfAAmG4Shw=
 github.com/fluxcd/pkg/testserver v0.1.0 h1:nOYgM1HYFZNNSUFykuWDmrsxj4jQxUCvmLHWOQeqmyA=
 github.com/fluxcd/pkg/testserver v0.1.0/go.mod h1:fvt8BHhXw6c1+CLw1QFZxcQprlcXzsrL4rzXaiGM+Iw=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=


### PR DESCRIPTION
This PR updates the `fluxcd/pkg/ssa` package to v0.0.5 with the following improvements:
- remove `creationTimestamp` metadata before apply (this field is read-only and should not be in Git)
- improve Secrets drift detection by comparing the `data` and `stringData` fields
- improve ConfigMap drift detection by comparing the `data` and `binaryData` fields

This PR contains a test for confirming that SOPS encrypted secrets no longer generate change events on each reconciliation.

Fix: #450 