### PR TITLE
Improve drift detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ docker-build:
 	docker buildx build \
 	--platform=$(BUILD_PLATFORMS) \
 	-t ${IMG} \
+	--load \
 	${BUILD_ARGS} .
 
 # Push the docker image

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.2.0
 	github.com/fluxcd/pkg/apis/meta v0.10.1
 	github.com/fluxcd/pkg/runtime v0.12.2
-	github.com/fluxcd/pkg/ssa v0.0.7
+	github.com/fluxcd/pkg/ssa v0.1.0
 	github.com/fluxcd/pkg/testserver v0.1.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/source-controller/api v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.1/go.mod h1:yUblM2vg+X8TE3A2VvJfdhkGmg+uqB
 github.com/fluxcd/pkg/runtime v0.12.0/go.mod h1:EyaTR2TOYcjL5U//C4yH3bt2tvTgIOSXpVRbWxUn/C4=
 github.com/fluxcd/pkg/runtime v0.12.2 h1:4iOpx2j/w15kNemDOnZrF6ugJ/rhSmRu7aI+xn23+BI=
 github.com/fluxcd/pkg/runtime v0.12.2/go.mod h1:tuWdqpWPhgjQvYrSnojdZ4plyU8DRU1NDzsfOhnzl2g=
-github.com/fluxcd/pkg/ssa v0.0.7 h1:RWKN+iPZ9oPg+5Tj4v9bxxeazsAnmmajxPS6Y1uh/uM=
-github.com/fluxcd/pkg/ssa v0.0.7/go.mod h1:B/6V2gF3zq3P6EstM/qTmOEUf3YgOh1ybFfAAmG4Shw=
+github.com/fluxcd/pkg/ssa v0.1.0 h1:JqKuujOpH/L+WlNJx7wdLhLOPzA7EnQl2oMAGKzIAss=
+github.com/fluxcd/pkg/ssa v0.1.0/go.mod h1:B/6V2gF3zq3P6EstM/qTmOEUf3YgOh1ybFfAAmG4Shw=
 github.com/fluxcd/pkg/testserver v0.1.0 h1:nOYgM1HYFZNNSUFykuWDmrsxj4jQxUCvmLHWOQeqmyA=
 github.com/fluxcd/pkg/testserver v0.1.0/go.mod h1:fvt8BHhXw6c1+CLw1QFZxcQprlcXzsrL4rzXaiGM+Iw=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=


### PR DESCRIPTION
Update `github.com/fluxcd/pkg/ssa` to v0.1.0 to remove server-side generated fields (metadata and status) before checking for semantic equality. Removing the server generated fields means that we no longer have to look for `spec` to properly detect drift.

Fix: https://github.com/fluxcd/flux2/issues/1934