### PR TITLE
Makefile minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ endif
 # Allows for defining additional Docker buildx arguments, e.g. '--push'.
 BUILD_ARGS ?=
 # Architectures to build images for.
-BUILD_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
+BUILD_PLATFORMS ?= linux/amd64
 
 all: manager
 
 # Download the envtest binaries to testbin
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-ENVTEST_AKUBERNETES_VERSION=latest
+ENVTEST_KUBERNETES_VERSION?=latest
 install-envtest: setup-envtest
-	$(SETUP_ENVTEST) use $(ENVTEST_AKUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR)
+	$(SETUP_ENVTEST) use $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR)
 
 # Run controller tests
-KUBEBUILDER_ASSETS?="$(shell $(SETUP_ENVTEST) use -i $(ENVTEST_AKUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
+KUBEBUILDER_ASSETS?="$(shell $(SETUP_ENVTEST) use -i $(ENVTEST_KUBERNETES_VERSION) --bin-dir=$(ENVTEST_ASSETS_DIR) -p path)"
 test: generate fmt vet manifests api-docs download-crd-deps install-envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/...  -v -coverprofile cover.out
 


### PR DESCRIPTION
- Set `BUILD_PLATFORMS` to `linux/amd64` only by default to allow exporting the
  built image native to the platform.
- Rename `ENVTEST_AKUBERNETES_VERSION` to `ENVTEST_KUBERNETES_VERSION`.
- Use `?=` operator with `ENVTEST_KUBERNETES_VERSION` to allow setting it
  from environment variable.