### PR TITLE
workflows/e2e: Use buildkit local cache

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,14 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-ghcache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-ghcache-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -53,7 +61,18 @@ jobs:
             exit 1
           fi
       - name: Build container image
-        run: make docker-build IMG=test/kustomize-controller:latest BUILD_PLATFORMS=linux/amd64 BUILD_ARGS=--load
+        run: |
+          make docker-build IMG=test/kustomize-controller:latest \
+            BUILD_PLATFORMS=linux/amd64 \
+            BUILD_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache \
+              --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max"
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Load test image
         run: kind load docker-image test/kustomize-controller:latest
       - name: Install CRDs


### PR DESCRIPTION
Buildkit cache docs: https://github.com/moby/buildkit/tree/master#local-directory-1
Github action cache docs: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache

Cache restore from previous build: https://github.com/fluxcd/kustomize-controller/pull/462/checks?check_run_id=3883200739#step:6:18
Building and exporting when using cached layer takes about 30-40s.

Part of issue: https://github.com/fluxcd/flux2/issues/1910 
