### PR TITLE
Warn when secrets are not decrypted before apply

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -660,6 +660,12 @@ func (r *KustomizationReconciler) apply(ctx context.Context, manager *ssa.Resour
 	resultSet := ssa.NewChangeSet()
 
 	for _, u := range objects {
+		if IsEncryptedSecret(u) {
+			return false, nil,
+				fmt.Errorf("%s is SOPS encryted, configuring decryption is required for this secret to be reconciled",
+					ssa.FmtUnstructured(u))
+		}
+
 		if ssa.IsClusterDefinition(u) {
 			stageOne = append(stageOne, u)
 		} else {

--- a/controllers/kustomization_decryptor.go
+++ b/controllers/kustomization_decryptor.go
@@ -33,6 +33,7 @@ import (
 	"go.mozilla.org/sops/v3/cmd/sops/formats"
 	"go.mozilla.org/sops/v3/keyservice"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -287,4 +288,14 @@ func isDir(path string) (bool, error) {
 	}
 
 	return fileInfo.IsDir(), nil
+}
+
+// IsEncryptedSecret checks if the given object is a Kubernetes Secret encrypted with Mozilla SOPS.
+func IsEncryptedSecret(object *unstructured.Unstructured) bool {
+	if object.GetKind() == "Secret" && object.GetAPIVersion() == "v1" {
+		if _, found, _ := unstructured.NestedFieldNoCopy(object.Object, "sops"); found {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
If decryption is not enabled, SOPS encrypted secrets will fail to apply with a validation error that doesn't give any hints. It's better to exit early and throw an error that tells users to enable decryption.
