### PR TITLE
Replace deprecated dependencies

### DIFF
--- a/controllers/kustomization_force_test.go
+++ b/controllers/kustomization_force_test.go
@@ -63,6 +63,7 @@ stringData:
 	}
 
 	artifact, err := testServer.ArtifactFromFiles(manifests(id, randStringRunes(5)))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create artifact from files")
 
 	repositoryName := types.NamespacedName{
 		Name:      fmt.Sprintf("force-%s", randStringRunes(5)),

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -24,12 +24,12 @@ import (
 	"strings"
 	"sync"
 
-	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
 	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"

--- a/controllers/kustomization_impersonation.go
+++ b/controllers/kustomization_impersonation.go
@@ -173,7 +173,7 @@ func (ki *KustomizeImpersonation) getKubeConfig(ctx context.Context) ([]byte, er
 	}
 
 	var kubeConfig []byte
-	for k, _ := range secret.Data {
+	for k := range secret.Data {
 		if k == "value" || k == "value.yaml" {
 			kubeConfig = secret.Data[k]
 			break

--- a/controllers/kustomization_indexers.go
+++ b/controllers/kustomization_indexers.go
@@ -61,7 +61,7 @@ func (r *KustomizationReconciler) requestsForRevisionChangeOf(indexKey string) f
 		if err != nil {
 			return nil
 		}
-		reqs := make([]reconcile.Request, len(sorted), len(sorted))
+		reqs := make([]reconcile.Request, len(sorted))
 		for i := range sorted {
 			reqs[i].NamespacedName.Name = sorted[i].Name
 			reqs[i].NamespacedName.Namespace = sorted[i].Namespace

--- a/controllers/kustomization_prune_test.go
+++ b/controllers/kustomization_prune_test.go
@@ -272,10 +272,10 @@ data:
 		empty := []testserver.File{
 			{
 				Name: "kustomization.yaml",
-				Body: fmt.Sprintf(`---
+				Body: `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-`),
+`,
 			},
 		}
 		artifact, err := testServer.ArtifactFromFiles(empty)
@@ -400,10 +400,10 @@ data:
 		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: id, Namespace: id}, resultSecret)).Should(Succeed())
 		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: id, Namespace: id}, resultConfig)).Should(Succeed())
 
-		name, _ := resultConfig.GetLabels()["kustomize.toolkit.fluxcd.io/name"]
+		name := resultConfig.GetLabels()["kustomize.toolkit.fluxcd.io/name"]
 		g.Expect(name).Should(BeIdenticalTo(kustomizationKey.Name))
 
-		namespace, _ := resultConfig.GetLabels()["kustomize.toolkit.fluxcd.io/namespace"]
+		namespace := resultConfig.GetLabels()["kustomize.toolkit.fluxcd.io/namespace"]
 		g.Expect(namespace).Should(BeIdenticalTo(kustomizationKey.Namespace))
 	})
 

--- a/controllers/kustomization_transformer_test.go
+++ b/controllers/kustomization_transformer_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -55,7 +54,7 @@ func TestKustomizationReconciler_KustomizeTransformer(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	repositoryName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 
@@ -178,7 +177,7 @@ func TestKustomizationReconciler_KustomizeTransformerFiles(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	repositoryName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 
@@ -297,7 +296,7 @@ func TestKustomizationReconciler_FluxTransformers(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	repositoryName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 

--- a/controllers/kustomization_varsub_test.go
+++ b/controllers/kustomization_varsub_test.go
@@ -67,7 +67,7 @@ metadata:
 	g.Expect(err).NotTo(HaveOccurred())
 
 	repositoryName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 
@@ -75,7 +75,7 @@ metadata:
 	g.Expect(err).NotTo(HaveOccurred())
 
 	configName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 	config := &corev1.ConfigMap{
@@ -88,7 +88,7 @@ metadata:
 	g.Expect(k8sClient.Create(context.Background(), config)).Should(Succeed())
 
 	secretName := types.NamespacedName{
-		Name:      fmt.Sprintf("%s", randStringRunes(5)),
+		Name:      randStringRunes(5),
 		Namespace: id,
 	}
 	secret := &corev1.Secret{

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/fluxcd/kustomize-controller/api => ./api
 
 require (
 	filippo.io/age v1.0.0
+	github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603
 	github.com/fluxcd/kustomize-controller/api v0.18.0
@@ -21,7 +22,6 @@ require (
 	github.com/onsi/gomega v1.15.0
 	github.com/spf13/pflag v1.0.5
 	go.mozilla.org/sops/v3 v3.7.1
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
 	google.golang.org/grpc v1.42.0
 	k8s.io/api v0.22.2
@@ -31,6 +31,7 @@ require (
 	sigs.k8s.io/cli-utils v0.26.0
 	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/kustomize/api v0.10.1
+	sigs.k8s.io/kustomize/kyaml v0.13.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3 h1:XcF0cTDJeiuZ5NU8w7WUDge0HRwwNRmxj/GGk6KSA6g=
+github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -807,6 +809,7 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/sops/keyservice/server.go
+++ b/internal/sops/keyservice/server.go
@@ -9,8 +9,8 @@ import (
 
 	"go.mozilla.org/sops/v3/keyservice"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/fluxcd/kustomize-controller/internal/sops/age"
 	"github.com/fluxcd/kustomize-controller/internal/sops/pgp"
@@ -126,7 +126,7 @@ func keyToString(key *keyservice.Key) string {
 	case *keyservice.Key_PgpKey:
 		return fmt.Sprintf("PGP key with fingerprint %s", k.PgpKey.Fingerprint)
 	default:
-		return fmt.Sprintf("Unknown key type")
+		return "Unknown key type"
 	}
 }
 
@@ -141,7 +141,7 @@ func (ks Server) prompt(key *keyservice.Key, requestType string) error {
 		}
 	}
 	if response == "n" {
-		return grpc.Errorf(codes.PermissionDenied, "Request rejected by user")
+		return status.Errorf(codes.PermissionDenied, "Request rejected by user")
 	}
 	return nil
 }

--- a/internal/sops/pgp/keysource.go
+++ b/internal/sops/pgp/keysource.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 )
 
 // MasterKey is a PGP key used to securely store sops' data key by


### PR DESCRIPTION
This PR contains various small fixes reported by [staticcheck](https://staticcheck.io/) and replaces the following deprecated packages:

- `sigs.k8s.io/kustomize/api/filesys` -> `sigs.k8s.io/kustomize/kyaml/filesys`
- `google.golang.org/grpc` -> `google.golang.org/grpc/status`
- `golang.org/x/crypto/openpgp` -> `github.com/ProtonMail/go-crypto/openpgp`
- `golang.org/x/crypto/openpgp/armor` -> `github.com/ProtonMail/go-crypto/openpgp/armor`