### PR TITLE
Capture errors from file close operation

### DIFF
--- a/internal/sops/pgp/keysource.go
+++ b/internal/sops/pgp/keysource.go
@@ -295,7 +295,12 @@ func (key *MasterKey) loadRing(path string) (openpgp.EntityList, error) {
 	if err != nil {
 		return openpgp.EntityList{}, err
 	}
-	defer f.Close()
+	defer func() {
+		cerr := f.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 	keyring, err := openpgp.ReadKeyRing(f)
 	if err != nil {
 		return keyring, err


### PR DESCRIPTION
This is to address issue outlined in https://github.com/fluxcd/pkg/issues/174. I am following the second recommendation from the [blog](https://www.joeshaw.org/dont-defer-close-on-writable-files/) to capture potential error from file close operation.