### PR TITLE
Fix HPA diff (upstream bug)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.3.1
 	github.com/fluxcd/pkg/apis/meta v0.10.2
 	github.com/fluxcd/pkg/runtime v0.12.3
-	github.com/fluxcd/pkg/ssa v0.7.0
+	github.com/fluxcd/pkg/ssa v0.8.0
 	github.com/fluxcd/pkg/testserver v0.1.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/source-controller/api v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/fluxcd/pkg/apis/meta v0.10.2 h1:pnDBBEvfs4HaKiVAYgz+e/AQ8dLvcgmVfSeBr
 github.com/fluxcd/pkg/apis/meta v0.10.2/go.mod h1:KQ2er9xa6koy7uoPMZjIjNudB5p4tXs+w0GO6fRcy7I=
 github.com/fluxcd/pkg/runtime v0.12.3 h1:h21AZ3YG5MAP7DxFF9hfKrP+vFzys2L7CkUbPFjbP/0=
 github.com/fluxcd/pkg/runtime v0.12.3/go.mod h1:imJ2xYy/d4PbSinX2IefmZk+iS2c1P5fY0js8mCE4SM=
-github.com/fluxcd/pkg/ssa v0.7.0 h1:Svek9UO2whyQrePZW03XCX7ytUtZvJ2R01buXQKkUyU=
-github.com/fluxcd/pkg/ssa v0.7.0/go.mod h1:3brodT9mai+iKz4nizqZUESITGMoMr4CCdt5MdfyTXw=
+github.com/fluxcd/pkg/ssa v0.8.0 h1:f3fNpKFPncCoWMDvxnTqX+8LAAMb3ZXc1N41mzw54k8=
+github.com/fluxcd/pkg/ssa v0.8.0/go.mod h1:3brodT9mai+iKz4nizqZUESITGMoMr4CCdt5MdfyTXw=
 github.com/fluxcd/pkg/testserver v0.1.0 h1:nOYgM1HYFZNNSUFykuWDmrsxj4jQxUCvmLHWOQeqmyA=
 github.com/fluxcd/pkg/testserver v0.1.0/go.mod h1:fvt8BHhXw6c1+CLw1QFZxcQprlcXzsrL4rzXaiGM+Iw=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=


### PR DESCRIPTION
Update fluxcd/pkg/ssa to v0.8.0 that implements a [workaround](https://github.com/fluxcd/pkg/pull/207) for a Kubernetes API server-side apply dry-run bug where the HPA custom metrics are duplicated.

Fix: #494