### PR TITLE
Revoke kubectl managed fields ownership

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,8 +22,6 @@ jobs:
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          buildkitd-flags: "--debug"
       - name: Restore Go cache
         uses: actions/cache@v1
         with:
@@ -97,6 +95,27 @@ jobs:
           make dev-deploy IMG=test/kustomize-controller:latest
           kubectl -n kustomize-system rollout status deploy/source-controller --timeout=1m
           kubectl -n kustomize-system rollout status deploy/kustomize-controller --timeout=1m
+      - name: Run tests for removing kubectl managed fields
+        run: |
+          kubectl create ns managed-fields
+          kustomize build github.com/stefanprodan/podinfo//kustomize?ref=6.0.0 > /tmp/podinfo.yaml
+          kubectl -n managed-fields apply -f /tmp/podinfo.yaml
+          kubectl -n managed-fields apply -f ./config/testdata/managed-fields
+          kubectl -n managed-fields wait kustomization/podinfo --for=condition=ready --timeout=4m
+          OUTDATA=$(kubectl -n managed-fields get deploy podinfo --show-managed-fields -oyaml)
+          if echo "$OUTDATA" | grep -q "kubectl";then
+            echo "kubectl client-side manager not removed"
+            exit 1
+          fi
+          kubectl -n managed-fields apply --server-side --force-conflicts -f /tmp/podinfo.yaml
+          kubectl -n managed-fields annotate --overwrite kustomization/podinfo reconcile.fluxcd.io/requestedAt="$(date +%s)"
+          kubectl -n managed-fields wait kustomization/podinfo --for=condition=ready --timeout=4m
+          OUTDATA=$(kubectl -n managed-fields get deploy podinfo --show-managed-fields -oyaml)
+          if echo "$OUTDATA" | grep -q "kubectl";then
+            echo "kubectl server-side manager not removed"
+            exit 1
+          fi
+          kubectl delete ns managed-fields
       - name: Run overlays tests
         run: |
           kubectl -n kustomize-system apply -k ./config/testdata/overlays

--- a/config/testdata/managed-fields/podinfo.yaml
+++ b/config/testdata/managed-fields/podinfo.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: podinfo
+spec:
+  interval: 15m
+  path: "./kustomize/"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: podinfo
+  timeout: 1m
+  targetNamespace: managed-fields
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: podinfo
+spec:
+  interval: 5m
+  url: https://github.com/stefanprodan/podinfo
+  ref:
+    semver: "6.0.0"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v0.3.1
 	github.com/fluxcd/pkg/apis/meta v0.10.2
 	github.com/fluxcd/pkg/runtime v0.12.4
-	github.com/fluxcd/pkg/ssa v0.11.1
+	github.com/fluxcd/pkg/ssa v0.12.0
 	github.com/fluxcd/pkg/testserver v0.2.0
 	github.com/fluxcd/pkg/untar v0.1.0
 	github.com/fluxcd/source-controller/api v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/fluxcd/pkg/runtime v0.12.4 h1:gA27RG/+adN2/7Qe03PB46Iwmye/MusPCpuS4zQ
 github.com/fluxcd/pkg/runtime v0.12.4/go.mod h1:gspNvhAqodZgSmK1ZhMtvARBf/NGAlxmaZaIOHkJYsc=
 github.com/fluxcd/pkg/ssa v0.11.1 h1:iZMMe6Pdgt/sv3pZPJ5y4oRDa+8IXHbpPYgpjEmaq/8=
 github.com/fluxcd/pkg/ssa v0.11.1/go.mod h1:S+qig7BTOxop0c134y8Yv8/iQST4Kt7S2xXiFkP4VMA=
+github.com/fluxcd/pkg/ssa v0.12.0 h1:7nF4UigU9Zk/9P/nbzUP3ah8IRC+BpB64O9iu5VnvEo=
+github.com/fluxcd/pkg/ssa v0.12.0/go.mod h1:S+qig7BTOxop0c134y8Yv8/iQST4Kt7S2xXiFkP4VMA=
 github.com/fluxcd/pkg/testserver v0.2.0 h1:Mj0TapmKaywI6Fi5wvt1LAZpakUHmtzWQpJNKQ0Krt4=
 github.com/fluxcd/pkg/testserver v0.2.0/go.mod h1:bgjjydkXsZTeFzjz9Cr4heGANr41uTB1Aj1Q5qzuYVk=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=


### PR DESCRIPTION
This PR enforces Flux ownership of Kubernetes objects' fields that were applied on the cluster outside of the declared desired state. In addition, metadata annotations and labels removed from Git and are now removed from the cluster.

In order to undo changes made with `kubectl apply -f` and `kubectl apply --server-side --force-conflicts`, we have to replace `kubectl-*` managers with our own manager before the controller runs the server-side apply. 

In addition, this PR removes the kubectl last applied configuration annotation and Flux v1 & v2 deprecated metadata. 

References: 
- Fix: https://github.com/fluxcd/kustomize-controller/issues/486
- Fix: https://github.com/fluxcd/flux2/issues/2262
- Fix: #545 
- Followup: #426

Upstream bugs:
- https://github.com/kubernetes/kubernetes/issues/99003
- https://github.com/kubernetes/kubernetes/issues/107417

Test this PR using `ghcr.io/fluxcd/kustomize-controller:rc-e611de4e`.

To use the release candidate on your cluster, add the following image patch to `clusters/<cluster>/flux-system/kustomization.yaml`:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- gotk-components.yaml
- gotk-sync.yaml
images:
  - name: ghcr.io/fluxcd/kustomize-controller
    newName: ghcr.io/fluxcd/kustomize-controller
    newTag: rc-e611de4e
```

Big thanks to @SomtochiAma and @kingdonb for all the help validating this approach 🥇   