### PR TITLE
Allow setting a default service account for impersonation

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -86,8 +86,10 @@ type KustomizationReconciler struct {
 	StatusPoller          *polling.StatusPoller
 	ControllerName        string
 	NoCrossNamespaceRefs  bool
+	DefaultServiceAccount string
 }
 
+// KustomizationReconcilerOptions contains options for the KustomizationReconciler.
 type KustomizationReconcilerOptions struct {
 	MaxConcurrentReconciles   int
 	HTTPRetry                 int
@@ -339,7 +341,7 @@ func (r *KustomizationReconciler) reconcile(
 	}
 
 	// setup the Kubernetes client for impersonation
-	impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, dirPath)
+	impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount)
 	kubeClient, statusPoller, err := impersonation.GetClient(ctx)
 	if err != nil {
 		return kustomizev1.KustomizationNotReady(
@@ -882,7 +884,7 @@ func (r *KustomizationReconciler) finalize(ctx context.Context, kustomization ku
 		kustomization.Status.Inventory.Entries != nil {
 		objects, _ := ListObjectsInInventory(kustomization.Status.Inventory)
 
-		impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, "")
+		impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount)
 		kubeClient, _, err := impersonation.GetClient(ctx)
 		if err != nil {
 			// when impersonation fails, log the stale objects and continue with the finalization

--- a/controllers/kustomization_impersonation_test.go
+++ b/controllers/kustomization_impersonation_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/testserver"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestKustomizationReconciler_Impersonation(t *testing.T) {
+	g := NewWithT(t)
+	id := "imp-" + randStringRunes(5)
+	revision := "v1.0.0"
+
+	// reset default account
+	defer func() {
+		reconciler.DefaultServiceAccount = ""
+	}()
+
+	err := createNamespace(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+	err = createKubeConfigSecret(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create kubeconfig secret")
+
+	manifests := func(name string, data string) []testserver.File {
+		return []testserver.File{
+			{
+				Name: "config.yaml",
+				Body: fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s
+data:
+  key: "%[2]s"
+`, name, data),
+			},
+		}
+	}
+
+	artifact, err := testServer.ArtifactFromFiles(manifests(id, randStringRunes(5)))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create artifact from files")
+
+	repositoryName := types.NamespacedName{
+		Name:      randStringRunes(5),
+		Namespace: id,
+	}
+
+	err = applyGitRepository(repositoryName, artifact, revision)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	kustomizationKey := types.NamespacedName{
+		Name:      randStringRunes(5),
+		Namespace: id,
+	}
+	kustomization := &kustomizev1.Kustomization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kustomizationKey.Name,
+			Namespace: kustomizationKey.Namespace,
+		},
+		Spec: kustomizev1.KustomizationSpec{
+			Interval: metav1.Duration{Duration: time.Minute},
+			Path:     "./",
+			KubeConfig: &kustomizev1.KubeConfig{
+				SecretRef: meta.LocalObjectReference{
+					Name: "kubeconfig",
+				},
+			},
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Name:      repositoryName.Name,
+				Namespace: repositoryName.Namespace,
+				Kind:      sourcev1.GitRepositoryKind,
+			},
+			TargetNamespace: id,
+		},
+	}
+
+	g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
+
+	resultK := &kustomizev1.Kustomization{}
+	readyCondition := &metav1.Condition{}
+
+	t.Run("reconciles as cluster admin", func(t *testing.T) {
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			readyCondition = apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+			return resultK.Status.LastAppliedRevision == revision
+		}, timeout, time.Second).Should(BeTrue())
+
+		g.Expect(readyCondition.Reason).To(Equal(meta.ReconciliationSucceededReason))
+	})
+
+	t.Run("fails to reconcile impersonating the default service account", func(t *testing.T) {
+		reconciler.DefaultServiceAccount = "default"
+		revision = "v2.0.0"
+		err = applyGitRepository(repositoryName, artifact, revision)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			readyCondition = apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+			return apimeta.IsStatusConditionFalse(resultK.Status.Conditions, meta.ReadyCondition)
+		}, timeout, time.Second).Should(BeTrue())
+
+		g.Expect(readyCondition.Reason).To(Equal(meta.ReconciliationFailedReason))
+		g.Expect(readyCondition.Message).To(ContainSubstring("system:serviceaccount:%s:default", id))
+	})
+
+	t.Run("reconciles impersonating service account", func(t *testing.T) {
+		sa := corev1.ServiceAccount{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ServiceAccount",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: id,
+			},
+		}
+		g.Expect(k8sClient.Create(context.Background(), &sa)).To(Succeed())
+
+		crb := rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: id,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "test",
+					Namespace: id,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+		}
+		g.Expect(k8sClient.Create(context.Background(), &crb)).To(Succeed())
+
+		saK := &kustomizev1.Kustomization{}
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), saK)
+		g.Expect(err).NotTo(HaveOccurred())
+		saK.Spec.ServiceAccountName = "test"
+		err = k8sClient.Update(context.Background(), saK)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		revision = "v3.0.0"
+		err = applyGitRepository(repositoryName, artifact, revision)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			readyCondition = apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+			return resultK.Status.LastAppliedRevision == revision
+		}, timeout, time.Second).Should(BeTrue())
+
+		g.Expect(readyCondition.Reason).To(Equal(meta.ReconciliationSucceededReason))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 		aclOptions            acl.Options
 		watchAllNamespaces    bool
 		httpRetry             int
+		defaultServiceAccount string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -82,6 +83,7 @@ func main() {
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
+	flag.StringVar(&defaultServiceAccount, "default-service-account", "", "Default service account used for impersonation.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
@@ -133,6 +135,7 @@ func main() {
 
 	if err = (&controllers.KustomizationReconciler{
 		ControllerName:        controllerName,
+		DefaultServiceAccount: defaultServiceAccount,
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		EventRecorder:         mgr.GetEventRecorderFor(controllerName),


### PR DESCRIPTION
Introduce the flag `--default-service-account` for allowing cluster admins to enforce impersonation across the cluster without having to use an admission controller. 

When the flag is set to a value that's not empty string, all Kustomizations which don't have `spec.serviceAccountName` specified, they will use the service account name provided by `--default-service-account=<SA Name>` in the namespace of the object.

**Breaking changes**: 
- When `--default-service-account=<SA name>` and/or `spec.ServiceAccountName` are specified, the controller no longer queries the API to extract and use the SA token. Instead, the controller relies on the Kubernetes impersonation feature to run the reconciliation under the `system:serviceaccount:<SA Namespace>:<SA Name>` identity. This impacts only clusters with custom made tokens and `automountServiceAccountToken` disabled. If a service account token points to a different identity (which should never be the case), then the controller will fail to reconcile with `Forbidden : User "system:serviceaccount:my-namespace:my-sa-name" cannot patch resource`.
- When both `spec.kubeConfig` and `spec.ServiceAccountName` are specified, the controller will impersonate the service account on the target cluster, previously the controller ignored the service account. 

Fix: #422
Part of: https://github.com/fluxcd/flux2/issues/2340