### PR TITLE
Clarify spec.path in API docs

### DIFF
--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -283,10 +283,12 @@ On multi-tenant clusters, platform admins can disable cross-namespace references
 
 ## Generate kustomization.yaml
 
-If your repository contains plain Kubernetes manifests, the `kustomization.yaml`
-file is automatically generated for all the Kubernetes manifests
-in the `spec.path` and sub-directories. This expects all YAML files present under that path to be valid kubernetes manifests
-and needs non-kubernetes ones to be excluded using `.sourceignore` file or `spec.ignore` on `GitRepository` object.
+If your repository contains plain Kubernetes manifests, the
+`kustomization.yaml` file is automatically generated for all the Kubernetes
+manifests in the `spec.path` of the Flux `Kustomization` and sub-directories.
+This expects all YAML files present under that path to be valid kubernetes
+manifests and needs non-kubernetes ones to be excluded using `.sourceignore`
+file or `spec.ignore` on `GitRepository` object.
 
 Example of excluding CI workflows and SOPS config files:
 


### PR DESCRIPTION
Fixes fluxcd/flux2#2357 - Docs accessibility

It's clear what was intended here if you know that Flux Kustomization has `spec.path` and GitRepository doesn't have any such a field, but that's presumptive about the user's knowledge. Let's not assume they've already learned and retained that.