### PR TITLE
Tolerate absence of resources in post-build substitution

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta2
 
 import (
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -207,6 +207,13 @@ type SubstituteReference struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name"`
+
+	// Optional indicates whether the referenced resource must exist, or whether to
+	// tolerate its absence. If true and the referenced resource is absent, proceed
+	// as if the resource was present but empty, without any variables defined.
+	// +kubebuilder:default:=false
+	// +optional
+	Optional bool `json:"optional,omitempty"`
 }
 
 // KustomizationStatus defines the observed state of a kustomization.

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -894,6 +894,14 @@ spec:
                           maxLength: 253
                           minLength: 1
                           type: string
+                        optional:
+                          default: false
+                          description: Optional indicates whether the referenced resource
+                            must exist, or whether to tolerate its absence. If true
+                            and the referenced resource is absent, proceed as if the
+                            resource was present but empty, without any variables
+                            defined.
+                          type: boolean
                       required:
                       - kind
                       - name

--- a/controllers/kustomization_varsub.go
+++ b/controllers/kustomization_varsub.go
@@ -51,7 +51,7 @@ func substituteVariables(
 				return nil, fmt.Errorf("substitute from 'ConfigMap/%s' error: %w", reference.Name, err)
 			}
 			for k, v := range resource.Data {
-				vars[k] = strings.Replace(v, "\n", "", -1)
+				vars[k] = strings.ReplaceAll(v, "\n", "")
 			}
 		case "Secret":
 			resource := &corev1.Secret{}
@@ -59,7 +59,7 @@ func substituteVariables(
 				return nil, fmt.Errorf("substitute from 'Secret/%s' error: %w", reference.Name, err)
 			}
 			for k, v := range resource.Data {
-				vars[k] = strings.Replace(string(v), "\n", "", -1)
+				vars[k] = strings.ReplaceAll(string(v), "\n", "")
 			}
 		}
 	}
@@ -67,7 +67,7 @@ func substituteVariables(
 	// load in-line vars (overrides the ones from resources)
 	if kustomization.Spec.PostBuild.Substitute != nil {
 		for k, v := range kustomization.Spec.PostBuild.Substitute {
-			vars[k] = strings.Replace(v, "\n", "", -1)
+			vars[k] = strings.ReplaceAll(v, "\n", "")
 		}
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -121,8 +121,11 @@ func runInContext(registerControllers func(*testenv.Environment), run func() err
 		panic(fmt.Sprintf("Failed to create k8s client: %v", err))
 	}
 
-	// Create a vault test instance
+	// Create a Vault test instance.
 	pool, resource, err := createVaultTestInstance()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create Vault instance: %v", err))
+	}
 	defer func() {
 		pool.Purge(resource)
 	}()

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -1126,6 +1126,20 @@ string
 referring resource.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>optional</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional indicates whether the referenced resource must exist, or whether to
+tolerate its absence. If true and the referenced resource is absent, proceed
+as if the resource was present but empty, without any variables defined.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -285,10 +285,10 @@ On multi-tenant clusters, platform admins can disable cross-namespace references
 
 If your repository contains plain Kubernetes manifests, the
 `kustomization.yaml` file is automatically generated for all the Kubernetes
-manifests in the `spec.path` of the Flux `Kustomization` and sub-directories.
-This expects all YAML files present under that path to be valid kubernetes
-manifests and needs non-kubernetes ones to be excluded using `.sourceignore`
-file or `spec.ignore` on `GitRepository` object.
+manifests in the directory tree specified in the `spec.path` field of the Flux `Kustomization`.
+All YAML files present under that path must be valid Kubernetes
+manifests, unless they're excluded either by way of the `.sourceignore`
+file or the `spec.ignore` field on the corresponding `GitRepository` object.
 
 Example of excluding CI workflows and SOPS config files:
 
@@ -1053,10 +1053,10 @@ spec:
 ### HashiCorp Vault
 
 Export the `VAULT_ADDR`  and `VAULT_TOKEN` environment variables to your shell,
-then use `sops` to encrypt a kubernetes secret (see [HashiCorp Vault](https://www.vaultproject.io/docs/secrets/transit)
+then use `sops` to encrypt a Kubernetes Secret (see [HashiCorp Vault](https://www.vaultproject.io/docs/secrets/transit)
 for more details on enabling the transit backend and [sops](https://github.com/mozilla/sops#encrypting-using-hashicorp-vault)).
 
-Then use `sops` to encrypt a kubernetes secret:
+Then use `sops` to encrypt a Kubernetes Secret:
 
 ```console
 $ export VAULT_ADDR=https://vault.example.com:8200

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -748,6 +748,16 @@ With `spec.postBuild.substituteFrom` you can provide a list of ConfigMaps and Se
 from which the variables are loaded.
 The ConfigMap and Secret data keys are used as the var names.
 
+The `spec.postBuild.substituteFrom.optional` field indicates how the
+controller should handle a referenced ConfigMap or Secret being absent
+at renconciliation time. The controller's default behavior ― with
+`optional` unspecified or set to `false` ― has it fail reconciliation if
+the referenced object is missing. By setting the `optional` field to
+`true`, you can indicate that controller should use the referenced
+object if it's there, but also tolerate its absence, treating that
+absence as if the object had been present but empty, defining no
+variables.
+
 This offers basic templating for your manifests including support
 for [bash string replacement functions](https://github.com/drone/envsubst) e.g.:
 
@@ -790,8 +800,11 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-vars
+        # Use this ConfigMap if it exists, but proceed if it doesn't.
+        optional: true
       - kind: Secret
         name: cluster-secret-vars
+        # Fail if this Secret does not exist.
 ```
 
 Note that for substituting variables in a secret, `spec.stringData` field must be used i.e


### PR DESCRIPTION
In a _Kustomization_'s post-build substitution sources, introduce a new "Optional" field to allow referencing a Kubernetes _ConfigMap_ or _Secret_ that may not exist at time of reconciliation. Treat substitution when the referenced object is missing as if the object had been present but empty, lacking any variable bindings.

Retain the longstanding behavior of interpreting references to Kubernetes objects being mandatory by default, such that reconciliation fails if such a referenced object does not exist. Only when the "Optional" field is set to true will reconciliation tolerate finding the referenced object to be missing.

Fixes #565.