### PR TITLE
api: Move Status in CRD printcolumn to the end

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -333,9 +333,9 @@ func (in *Kustomization) GetStatusConditions() *[]metav1.Condition {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=ks
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 
 // Kustomization is the Schema for the kustomizations API.
 type Kustomization struct {

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -554,15 +554,15 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1beta2
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Status content could be very long compare to other fields. Moving it to
the end helps improve the visibility of other fields.

Ref: https://github.com/fluxcd/flux2/issues/2385