### PR TITLE
Use main go.mod for fuzz tests

### DIFF
--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -54,7 +54,15 @@ cp ../../config/crd/bases/*.yaml testdata/crd
 cp ../../controllers/testdata/sops/age.txt testdata/sops
 cp ../../controllers/testdata/sops/pgp.asc testdata/sops
 
-go mod tidy
+# Use main go.mod in order to conserve the same version across all dependencies.
+cp ../../go.mod .
+cp ../../go.sum .
+
+sed -i 's;module .*;module github.com/fluxcd/kustomize-controller/tests/fuzz;g' go.mod
+sed -i 's;api => ./api;api => ../../api;g' go.mod
+echo "replace github.com/fluxcd/kustomize-controller => ../../" >> go.mod
+
+go mod download
 
 compile_go_fuzzer "${PROJECT_PATH}/tests/fuzz/" FuzzControllers fuzz_controllers
 


### PR DESCRIPTION
Fixes issues building fuzzers whilst also ensuring that they are linking back to current version of kustomizer-controller and ./api.