### PR TITLE
Fix revision naming for events

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -983,7 +983,7 @@ func (r *KustomizationReconciler) event(ctx context.Context, kustomization kusto
 		metadata = map[string]string{}
 	}
 	if revision != "" {
-		metadata[kustomizev1.GroupVersion.Group+"/revision"] = revision
+		metadata["revision"] = revision
 	}
 
 	reason := severity

--- a/controllers/kustomization_decryptor_test.go
+++ b/controllers/kustomization_decryptor_test.go
@@ -217,7 +217,7 @@ func TestKustomizationReconciler_Decryptor(t *testing.T) {
 			return resultK.Status.LastAttemptedRevision == revision
 		}, timeout, time.Second).Should(BeTrue())
 
-		events := getEvents(resultK.GetName(), map[string]string{"kustomize.toolkit.fluxcd.io/revision": revision})
+		events := getEvents(resultK.GetName(), map[string]string{"revision": revision})
 		g.Expect(len(events)).To(BeIdenticalTo(1))
 		g.Expect(events[0].Message).Should(ContainSubstring("Reconciliation finished"))
 		g.Expect(events[0].Message).ShouldNot(ContainSubstring("configured"))

--- a/controllers/kustomization_force_test.go
+++ b/controllers/kustomization_force_test.go
@@ -137,7 +137,7 @@ stringData:
 		g.Expect(apimeta.IsStatusConditionTrue(resultK.Status.Conditions, meta.ReadyCondition)).To(BeFalse())
 
 		t.Run("emits validation error event", func(t *testing.T) {
-			events := getEvents(resultK.GetName(), map[string]string{"kustomize.toolkit.fluxcd.io/revision": revision})
+			events := getEvents(resultK.GetName(), map[string]string{"revision": revision})
 			g.Expect(len(events) > 0).To(BeTrue())
 			g.Expect(events[0].Type).To(BeIdenticalTo("Warning"))
 			g.Expect(events[0].Message).To(ContainSubstring("invalid, error: secret is immutable"))

--- a/controllers/kustomization_wait_test.go
+++ b/controllers/kustomization_wait_test.go
@@ -167,7 +167,7 @@ data:
 	})
 
 	t.Run("emits unhealthy event", func(t *testing.T) {
-		events := getEvents(resultK.GetName(), map[string]string{"kustomize.toolkit.fluxcd.io/revision": revision})
+		events := getEvents(resultK.GetName(), map[string]string{"revision": revision})
 		g.Expect(len(events) > 0).To(BeTrue())
 		g.Expect(events[len(events)-1].Type).To(BeIdenticalTo("Warning"))
 		g.Expect(events[len(events)-1].Message).To(ContainSubstring("does-not-exists"))
@@ -190,7 +190,7 @@ data:
 
 	t.Run("emits recovery event", func(t *testing.T) {
 		expectedMessage := "Health check passed"
-		events := getEvents(resultK.GetName(), map[string]string{"kustomize.toolkit.fluxcd.io/revision": revision})
+		events := getEvents(resultK.GetName(), map[string]string{"revision": revision})
 		g.Expect(len(events) > 1).To(BeTrue())
 		g.Expect(events[len(events)-2].Type).To(BeIdenticalTo("Normal"))
 		g.Expect(events[len(events)-2].Message).To(ContainSubstring(expectedMessage))


### PR DESCRIPTION
Remove the FQDN from the revision field as it breaks the events contract in notification-controller. With the FQDN, the commit status updates no longer work, because notification-controller expects a metadata key named `revision` not `kustomize.toolkit.fluxcd.io/revision`.
