### PR TITLE
Ensure annotations are prefixed with Group FQDN

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -283,7 +283,7 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		kustomization.Spec.Interval.Duration.String())
 	log.Info(msg, "revision", source.GetArtifact().Revision)
 	r.event(ctx, reconciledKustomization, source.GetArtifact().Revision, events.EventSeverityInfo,
-		msg, map[string]string{"commit_status": "update"})
+		msg, map[string]string{kustomizev1.GroupVersion.Group + "/commit_status": "update"})
 	return ctrl.Result{RequeueAfter: kustomization.Spec.Interval.Duration}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 
-// pin kustomize to v4.4.1
+// pin kustomize to v4.5.2
 replace (
 	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.10.1
 	sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.13.0


### PR DESCRIPTION
This to facilitate improvements on the notification-controller side,
where annotations prefixed with the FQDN of the Group of the Involved
Object will be transformed into "fields".
