### PR TITLE
Add kubeconfig flags

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,8 +52,6 @@ jobs:
         uses: fluxcd/pkg/actions/kubectl@main
         with:
           version: 1.21.2
-      - name: Setup SOPS
-        uses: fluxcd/pkg/actions/sops@main
       - name: Enable integration tests
         # Only run integration tests for main branch
         if: github.ref == 'refs/heads/main'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,7 @@ In addition to the above, the following dependencies are also used by some of th
 - `controller-gen` (v0.7.0)
 - `gen-crd-api-reference-docs` (v0.3.0)
 - `setup-envtest` (latest)
+- `sops` (v3.7.2)
 
 If any of the above dependencies are not present on your system, the first invocation of a `make` target that requires them will install them.
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fluxcd/pkg/apis/acl v0.0.3
 	github.com/fluxcd/pkg/apis/kustomize v0.3.2
 	github.com/fluxcd/pkg/apis/meta v0.12.1
-	github.com/fluxcd/pkg/runtime v0.13.2
+	github.com/fluxcd/pkg/runtime v0.13.3
 	github.com/fluxcd/pkg/ssa v0.15.1
 	github.com/fluxcd/pkg/testserver v0.2.0
 	github.com/fluxcd/pkg/untar v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/fluxcd/pkg/apis/kustomize v0.3.2 h1:ULoAwOOekHf5cy6mYIwL+K6v8/cfcNVVb
 github.com/fluxcd/pkg/apis/kustomize v0.3.2/go.mod h1:p8iAH5TeqMBnnxkkpCNNDvWYfKlNRx89a6WKOo+hJHA=
 github.com/fluxcd/pkg/apis/meta v0.12.1 h1:m5PfKAqbqWBvGp9+JRj1sv+xNkGsHwUVf+3rJ8wm6SE=
 github.com/fluxcd/pkg/apis/meta v0.12.1/go.mod h1:f8YVt70/KAhqzZ7xxhjvqyzKubOYx2pAbakb/FfCEg8=
-github.com/fluxcd/pkg/runtime v0.13.2 h1:6jkQQUbp17WxHsbozlJFCvHmOS4JIB+yB20CdCd8duE=
-github.com/fluxcd/pkg/runtime v0.13.2/go.mod h1:dzWNKqFzFXeittbpFcJzR3cdC9CWlbzw+pNOgaVvF/0=
+github.com/fluxcd/pkg/runtime v0.13.3 h1:k0Xun+RoEC/F6iuAPTA6rQb+I4B4oecBx6pOcodX11A=
+github.com/fluxcd/pkg/runtime v0.13.3/go.mod h1:dzWNKqFzFXeittbpFcJzR3cdC9CWlbzw+pNOgaVvF/0=
 github.com/fluxcd/pkg/ssa v0.15.1 h1:HXAT+K6c9Yy8Evxdyk3DU0KTk3yZ+fwgTEEzU1W/1V8=
 github.com/fluxcd/pkg/ssa v0.15.1/go.mod h1:OSXVu/uKPbhzBRljA359+WYxbXtMUNbkADlrS3Rm+gE=
 github.com/fluxcd/pkg/testserver v0.2.0 h1:Mj0TapmKaywI6Fi5wvt1LAZpakUHmtzWQpJNKQ0Krt4=

--- a/internal/sops/azkv/keysource_integration_test.go
+++ b/internal/sops/azkv/keysource_integration_test.go
@@ -1,4 +1,5 @@
-// +tag integration
+//go:build integration
+// +build integration
 
 /*
 Copyright 2022 The Flux authors

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 		concurrent            int
 		requeueDependency     time.Duration
 		clientOptions         client.Options
+		kubeConfigOpts        client.KubeConfigOptions
 		logOptions            logger.Options
 		leaderElectionOptions leaderelection.Options
 		aclOptions            acl.Options
@@ -89,6 +90,7 @@ func main() {
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
 	aclOptions.BindFlags(flag.CommandLine)
+	kubeConfigOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(logger.NewLogger(logOptions))
@@ -139,6 +141,7 @@ func main() {
 		MetricsRecorder:       metricsRecorder,
 		StatusPoller:          polling.NewStatusPoller(mgr.GetClient(), mgr.GetRESTMapper(), polling.Options{}),
 		NoCrossNamespaceRefs:  aclOptions.NoCrossNamespaceRefs,
+		KubeConfigOpts:        kubeConfigOpts,
 	}).SetupWithManager(mgr, controllers.KustomizationReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
Two new flags were added to allow users to enable the use of user.Exec (`--insecure-kubeconfig-exec`) and InsecureTLS (`insecure-kubeconfig-tls`) in the kubeconfigs provided for remote apply.

Breaking change: both functionalities are no longer enabled by default.