### PR TITLE
sops/keyservice: properly fallback to default

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,7 +68,8 @@ jobs:
           make docker-build IMG=test/kustomize-controller:latest \
             BUILD_PLATFORMS=linux/amd64 \
             BUILD_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache \
-              --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max"
+              --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
+              --load"
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Allows for defining additional Docker buildx arguments, e.g. '--push'.
-BUILD_ARGS ?=
+BUILD_ARGS ?= --load
 # Architectures to build images for.
 BUILD_PLATFORMS ?= linux/amd64
 
@@ -106,7 +106,6 @@ docker-build:
 	docker buildx build \
 	--platform=$(BUILD_PLATFORMS) \
 	-t ${IMG} \
-	--load \
 	${BUILD_ARGS} .
 
 # Push the docker image

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kustomize-system
 resources:
-- https://github.com/fluxcd/source-controller/releases/download/v0.22.0/source-controller.crds.yaml
-- https://github.com/fluxcd/source-controller/releases/download/v0.22.0/source-controller.deployment.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.22.3/source-controller.crds.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.22.3/source-controller.deployment.yaml
 - ../crd
 - ../rbac
 - ../manager

--- a/controllers/kustomization_decryptor.go
+++ b/controllers/kustomization_decryptor.go
@@ -160,14 +160,6 @@ func (kd *KustomizeDecryptor) ImportKeys(ctx context.Context) error {
 		var ageIdentities []string
 		var vaultToken string
 		for name, value := range secret.Data {
-			if name == DecryptionAzureAuthFile {
-				azureConf := azkv.AADConfig{}
-				if err = azkv.LoadAADConfigFromBytes(value, &azureConf); err != nil {
-					return err
-				}
-				kd.azureAADConfig = &azureConf
-				continue
-			}
 			switch filepath.Ext(name) {
 			case ".asc":
 				keyPath, err := securejoin.SecureJoin(tmpDir, name)
@@ -182,12 +174,21 @@ func (kd *KustomizeDecryptor) ImportKeys(ctx context.Context) error {
 				}
 			case ".agekey":
 				ageIdentities = append(ageIdentities, string(value))
-			case ".vault-token":
-				// Make sure we have the absolute file name
+			case filepath.Ext(DecryptionVaultTokenFileName):
+				// Make sure we have the absolute name
 				if name == DecryptionVaultTokenFileName {
 					token := string(value)
 					token = strings.Trim(strings.TrimSpace(token), "\n")
 					vaultToken = token
+				}
+			case filepath.Ext(DecryptionAzureAuthFile):
+				// Make sure we have the absolute name
+				if name == DecryptionAzureAuthFile {
+					azureConf := azkv.AADConfig{}
+					if err = azkv.LoadAADConfigFromBytes(value, &azureConf); err != nil {
+						return err
+					}
+					kd.azureAADConfig = &azureConf
 				}
 			}
 		}

--- a/internal/sops/keyservice/server.go
+++ b/internal/sops/keyservice/server.go
@@ -165,8 +165,9 @@ func (ks Server) Encrypt(ctx context.Context,
 		// Fallback to default server if no custom settings are configured
 		// to ensure backwards compatibility with global configurations
 		if ks.AzureAADConfig == nil {
-			return ks.Encrypt(ctx, req)
+			return ks.DefaultServer.Encrypt(ctx, req)
 		}
+
 		ciphertext, err := ks.encryptWithAzureKeyvault(k.AzureKeyvaultKey, req.Plaintext)
 		if err != nil {
 			return nil, err
@@ -252,8 +253,9 @@ func (ks Server) Decrypt(ctx context.Context,
 		// Fallback to default server if no custom settings are configured
 		// to ensure backwards compatibility with global configurations
 		if ks.AzureAADConfig == nil {
-			return ks.Decrypt(ctx, req)
+			return ks.DefaultServer.Decrypt(ctx, req)
 		}
+
 		plaintext, err := ks.decryptWithAzureKeyvault(k.AzureKeyvaultKey, req.Ciphertext)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
(AMD64) image for testing available at: `hiddeco/kustomize-controller:fix-azkv-fallback-dc5486f`

Potentially addresses: https://github.com/fluxcd/kustomize-controller/issues/595