### PR TITLE
Update KubeConfig documentation

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -57,7 +57,12 @@ type KustomizationSpec struct {
 	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 
 	// The KubeConfig for reconciling the Kustomization on a remote cluster.
-	// When specified, KubeConfig takes precedence over ServiceAccountName.
+	// When used in combination with KustomizationSpec.ServiceAccountName,
+	// forces the controller to act on behalf of that Service Account at the
+	// target cluster.
+	// If the --default-service-account flag is set, its value will be used as
+	// a controller level fallback for when KustomizationSpec.ServiceAccountName
+	// is empty.
 	// +optional
 	KubeConfig *KubeConfig `json:"kubeConfig,omitempty"`
 

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -691,8 +691,11 @@ spec:
                 type: string
               kubeConfig:
                 description: The KubeConfig for reconciling the Kustomization on a
-                  remote cluster. When specified, KubeConfig takes precedence over
-                  ServiceAccountName.
+                  remote cluster. When used in combination with KustomizationSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at
+                  the target cluster. If the --default-service-account flag is set,
+                  its value will be used as a controller level fallback for when KustomizationSpec.ServiceAccountName
+                  is empty.
                 properties:
                   secretRef:
                     description: SecretRef holds the name to a secret that contains

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -139,7 +139,12 @@ KubeConfig
 <td>
 <em>(Optional)</em>
 <p>The KubeConfig for reconciling the Kustomization on a remote cluster.
-When specified, KubeConfig takes precedence over ServiceAccountName.</p>
+When used in combination with KustomizationSpec.ServiceAccountName,
+forces the controller to act on behalf of that Service Account at the
+target cluster.
+If the &ndash;default-service-account flag is set, its value will be used as
+a controller level fallback for when KustomizationSpec.ServiceAccountName
+is empty.</p>
 </td>
 </tr>
 <tr>
@@ -624,7 +629,12 @@ KubeConfig
 <td>
 <em>(Optional)</em>
 <p>The KubeConfig for reconciling the Kustomization on a remote cluster.
-When specified, KubeConfig takes precedence over ServiceAccountName.</p>
+When used in combination with KustomizationSpec.ServiceAccountName,
+forces the controller to act on behalf of that Service Account at the
+target cluster.
+If the &ndash;default-service-account flag is set, its value will be used as
+a controller level fallback for when KustomizationSpec.ServiceAccountName
+is empty.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
When the flag `--default-service-account` was added it slightly changed the behaviour of the `spec.KubeConfig` field. It now forces the impersonation to always take place, either via the contents of `spec.ServiceAccountName` or its fallback at controller level.