### PR TITLE
Bump alpine to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -a -o kustomize-controller main.go
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 
 RUN apk add --no-cache ca-certificates tini git openssh-client gnupg
 


### PR DESCRIPTION
Bump Alpine to the latest version

Alpine latest version includes a fix for libretls [CVE-2022-0778](https://gitlab.alpinelinux.org/alpine/aports/-/commit/91c7a9f3aa296b6d462c5634e7658ebdbff65bb9).

Signed-off-by: Maria Reynoso <maria.reynoso@jetstack.io>