### PR TITLE
Ensure generated temp dir is absolute on all OSes

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -300,7 +300,7 @@ func (r *KustomizationReconciler) reconcile(
 	revision := source.GetArtifact().Revision
 
 	// create tmp dir
-	tmpDir, err := os.MkdirTemp("", "kustomization-")
+	tmpDir, err := MkdirTempAbs("", "kustomization-")
 	if err != nil {
 		err = fmt.Errorf("tmp dir error: %w", err)
 		return kustomizev1.KustomizationNotReady(

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MkdirTempAbs creates a tmp dir and returns the absolute path to the dir.
+// This is required since certain OSes like MacOS create temporary files in
+// e.g. `/private/var`, to which `/var` is a symlink.
+func MkdirTempAbs(dir, pattern string) (string, error) {
+	tmpDir, err := os.MkdirTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("error evaluating symlink: %w", err)
+	}
+	return tmpDir, nil
+}


### PR DESCRIPTION
Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>
