### PR TITLE
Use Secret generator keys for SOPS format hint

### DIFF
--- a/controllers/kustomization_decryptor_test.go
+++ b/controllers/kustomization_decryptor_test.go
@@ -695,7 +695,7 @@ func TestKustomizeDecryptor_DecryptResource(t *testing.T) {
 		},
 	}
 
-	t.Run("SOPS encrypted resource", func(t *testing.T) {
+	t.Run("SOPS-encrypted Secret resource", func(t *testing.T) {
 		g := NewWithT(t)
 
 		kus := kustomization.DeepCopy()
@@ -736,7 +736,7 @@ func TestKustomizeDecryptor_DecryptResource(t *testing.T) {
 		g.Expect(got.MarshalJSON()).To(Equal(secretData))
 	})
 
-	t.Run("SOPS encrypted binary Secret data field", func(t *testing.T) {
+	t.Run("SOPS-encrypted binary-format Secret data field", func(t *testing.T) {
 		g := NewWithT(t)
 
 		kus := kustomization.DeepCopy()
@@ -771,7 +771,7 @@ func TestKustomizeDecryptor_DecryptResource(t *testing.T) {
 		g.Expect(got.GetDataMap()).To(HaveKeyWithValue("file.ini", base64.StdEncoding.EncodeToString(plainData)))
 	})
 
-	t.Run("SOPS encrypted YAML Secret data field", func(t *testing.T) {
+	t.Run("SOPS-encrypted YAML-format Secret data field", func(t *testing.T) {
 		g := NewWithT(t)
 
 		kus := kustomization.DeepCopy()
@@ -849,12 +849,14 @@ func TestKustomizeDecryptor_DecryptResource(t *testing.T) {
 
 func TestKustomizeDecryptor_decryptKustomizationEnvSources(t *testing.T) {
 	type file struct {
-		name       string
-		symlink    string
-		data       []byte
-		encrypt    bool
-		expectData bool
+		name           string
+		symlink        string
+		data           []byte
+		originalFormat *formats.Format
+		encrypt        bool
+		expectData     bool
 	}
+	binaryFormat := formats.Binary
 	tests := []struct {
 		name            string
 		wordirSuffix    string
@@ -869,6 +871,9 @@ func TestKustomizeDecryptor_decryptKustomizationEnvSources(t *testing.T) {
 			path: "subdir",
 			files: []file{
 				{name: "subdir/app.env", data: []byte("var1=value1\n"), encrypt: true, expectData: true},
+				// NB: Despite the file extension representing the SOPS-encrypted JSON output
+				// format, the original data is plain text, or "binary."
+				{name: "subdir/combination.json", data: []byte("The safe combination is ..."), originalFormat: &binaryFormat, encrypt: true, expectData: true},
 				{name: "subdir/file.txt", data: []byte("file"), encrypt: true, expectData: true},
 				{name: "secret.env", data: []byte("var2=value2\n"), encrypt: true, expectData: true},
 			},
@@ -877,13 +882,13 @@ func TestKustomizeDecryptor_decryptKustomizationEnvSources(t *testing.T) {
 					GeneratorArgs: kustypes.GeneratorArgs{
 						Name: "envSecret",
 						KvPairSources: kustypes.KvPairSources{
-							FileSources: []string{"file.txt"},
+							FileSources: []string{"file.txt", "combo=combination.json"},
 							EnvSources:  []string{"app.env", "../secret.env"},
 						},
 					},
 				},
 			},
-			expectVisited: []string{"subdir/app.env", "subdir/file.txt", "secret.env"},
+			expectVisited: []string{"subdir/app.env", "subdir/combination.json", "subdir/file.txt", "secret.env"},
 		},
 		{
 			name:  "decryption error",
@@ -987,7 +992,12 @@ func TestKustomizeDecryptor_decryptKustomizationEnvSources(t *testing.T) {
 				}
 				data := f.data
 				if f.encrypt {
-					format := formats.FormatForPath(f.name)
+					var format formats.Format
+					if f.originalFormat != nil {
+						format = *f.originalFormat
+					} else {
+						format = formats.FormatForPath(f.name)
+					}
 					data, err = d.sopsEncryptWithFormat(sops.Metadata{
 						KeyGroups: []sops.KeyGroup{
 							{&sopsage.MasterKey{Recipient: id.Recipient().String()}},
@@ -1159,7 +1169,7 @@ func TestKustomizeDecryptor_decryptSopsFile(t *testing.T) {
 
 				b, err := os.ReadFile(filepath.Join(tmpDir, f.name))
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(bytes.Compare(f.data, b) == 0).To(Equal(f.expectData))
+				g.Expect(bytes.Equal(f.data, b)).To(Equal(f.expectData))
 			}
 		})
 	}

--- a/controllers/kustomization_decryptor_test.go
+++ b/controllers/kustomization_decryptor_test.go
@@ -878,7 +878,7 @@ func TestKustomizeDecryptor_decryptKustomizationEnvSources(t *testing.T) {
 						Name: "envSecret",
 						KvPairSources: kustypes.KvPairSources{
 							FileSources: []string{"file.txt"},
-							EnvSources:  []string{"app.env", "key=../secret.env"},
+							EnvSources:  []string{"app.env", "../secret.env"},
 						},
 					},
 				},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -43,7 +43,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	kuberecorder "k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -68,7 +67,6 @@ var (
 	k8sClient    client.Client
 	testEnv      *testenv.Environment
 	testServer   *testserver.ArtifactServer
-	testEventsH  kuberecorder.EventRecorder
 	testMetricsH controller.Metrics
 	ctx          = ctrl.SetupSignalHandler()
 	kubeConfig   []byte


### PR DESCRIPTION
Rather than inspecting the source file name supplied to [_kustomize_'s _Secret_ generator](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/secretgenerator/) to determine the format of the SOPS-encrypted file content, instead inspect the _Secret_ key—when supplied separately from the source file name—as a more reliable heuristic.

Doing so allows _kustomization_ authors to name their SOPS-encrypted output files with a ".json" extension accurately reflecting the format in which SOPS writes its encrypted output, even if the encrypted content itself is not in JSON format.

See [preceding discussion in the "flux" channel](https://cloud-native.slack.com/archives/CLAJ40HV3/p1650920860479349) of the CNCF Slack workspace for the circuitous path I took to diagnose this change in behavior, with @hiddeco's help in pointing me to his recent #619 and suggesting the idea for the fix.