### PR TITLE
Disallow remote bases usage in Kustomize overlays

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -88,6 +88,7 @@ type KustomizationReconciler struct {
 	ControllerName        string
 	statusManager         string
 	NoCrossNamespaceRefs  bool
+	NoRemoteBases         bool
 	DefaultServiceAccount string
 	KubeConfigOpts        runtimeClient.KubeConfigOptions
 }
@@ -655,7 +656,7 @@ func (r *KustomizationReconciler) build(ctx context.Context, workDir string, kus
 		return nil, fmt.Errorf("error decrypting env sources: %w", err)
 	}
 
-	m, err := secureBuildKustomization(workDir, dirPath)
+	m, err := secureBuildKustomization(workDir, dirPath, !r.NoRemoteBases)
 	if err != nil {
 		return nil, fmt.Errorf("kustomize build failed: %w", err)
 	}

--- a/controllers/kustomization_generator_test.go
+++ b/controllers/kustomization_generator_test.go
@@ -26,8 +26,15 @@ func Test_secureBuildKustomization(t *testing.T) {
 	t.Run("remote build", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, err := secureBuildKustomization("testdata/remote", "testdata/remote")
+		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", true)
 		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("no remote build", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", false)
+		g.Expect(err).To(HaveOccurred())
 	})
 }
 
@@ -35,11 +42,11 @@ func Test_secureBuildKustomization_panic(t *testing.T) {
 	t.Run("build panic", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, err := secureBuildKustomization("testdata/panic", "testdata/panic")
+		_, err := secureBuildKustomization("testdata/panic", "testdata/panic", false)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("recovered from kustomize build panic"))
 		// Run again to ensure the lock is released
-		_, err = secureBuildKustomization("testdata/panic", "testdata/panic")
+		_, err = secureBuildKustomization("testdata/panic", "testdata/panic", false)
 		g.Expect(err).To(HaveOccurred())
 	})
 }

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -287,6 +287,10 @@ spec:
   path: "./deploy/production"
 ```
 
+For security and performance reasons, it is advised to disallow the usage of
+[remote bases](https://github.com/kubernetes-sigs/kustomize/blob/a7f4db7fb41e17b2c826a524f545e6174b4dc6ac/examples/remoteBuild.md)
+in Kustomize overlays. To enforce this setting, platform admins can use the `--no-remote-bases=true` flag.
+
 ## Source reference
 
 The Kustomization `spec.sourceRef` is a reference to an object managed by

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 		rateLimiterOptions    helper.RateLimiterOptions
 		aclOptions            acl.Options
 		watchAllNamespaces    bool
+		noRemoteBases         bool
 		httpRetry             int
 		defaultServiceAccount string
 	)
@@ -88,6 +89,8 @@ func main() {
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
 	flag.BoolVar(&watchAllNamespaces, "watch-all-namespaces", true,
 		"Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace.")
+	flag.BoolVar(&noRemoteBases, "no-remote-bases", false,
+		"Disallow remote bases usage in Kustomize overlays. When this flag is enabled, all resources must refer to local files included in the source artifact.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.StringVar(&defaultServiceAccount, "default-service-account", "", "Default service account used for impersonation.")
 	clientOptions.BindFlags(flag.CommandLine)
@@ -146,6 +149,7 @@ func main() {
 		EventRecorder:         eventRecorder,
 		MetricsRecorder:       metricsRecorder,
 		NoCrossNamespaceRefs:  aclOptions.NoCrossNamespaceRefs,
+		NoRemoteBases:         noRemoteBases,
 		KubeConfigOpts:        kubeConfigOpts,
 		StatusPoller: polling.NewStatusPoller(mgr.GetClient(), mgr.GetRESTMapper(), polling.Options{
 			CustomStatusReaders: []engine.StatusReader{jobStatusReader},


### PR DESCRIPTION
Add an optional flag for disabling Kustomize [remote bases](https://github.com/kubernetes-sigs/kustomize/blob/a7f4db7fb41e17b2c826a524f545e6174b4dc6ac/examples/remoteBuild.md).

While the `--no-remote-bases` is set to `false` by default, Flux users are encouraged to enable it on production system for security and performance reasons. Using Kustomize remote bases means that kustomize-controller must clone the remote repositories on every reconciliation instead of using the source-controller artifacts cache. Allowing remote bases on multi-tenant clusters, means platform admins have no control over which repositories make up the desired state. When this flag is enabled, all resources must refer to local files included in the source artifact, meaning that only the Flux sources defined in Git can affect the cluster state.
