### PR TITLE
Introduce SA check before configuring impersonation

### DIFF
--- a/controllers/kustomization_impersonation.go
+++ b/controllers/kustomization_impersonation.go
@@ -110,13 +110,18 @@ func (ki *KustomizeImpersonation) setImpersonationConfig(ctx context.Context, re
 	}
 
 	if name != "" {
+		c, err := client.New(restConfig, client.Options{})
+		if err != nil {
+			return err
+		}
+
 		serviceAccountName := types.NamespacedName{
 			Namespace: ki.kustomization.GetNamespace(),
 			Name:      name,
 		}
 
 		var serviceAccount corev1.ServiceAccount
-		if err := ki.Get(ctx, serviceAccountName, &serviceAccount); err != nil {
+		if err := c.Get(ctx, serviceAccountName, &serviceAccount); err != nil {
 			return fmt.Errorf("unable to set ImpersonationConfig for ServiceAccount '%s' error: %w", serviceAccountName.String(), err)
 		}
 

--- a/controllers/kustomization_impersonation_test.go
+++ b/controllers/kustomization_impersonation_test.go
@@ -49,6 +49,9 @@ func TestKustomizationReconciler_Impersonation(t *testing.T) {
 	err := createNamespace(id)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
 
+	err = createServiceAccount("default", id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create default service account")
+
 	err = createKubeConfigSecret(id)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to create kubeconfig secret")
 

--- a/controllers/kustomization_impersonation_test.go
+++ b/controllers/kustomization_impersonation_test.go
@@ -159,8 +159,8 @@ data:
 		}, timeout, time.Second).Should(BeTrue())
 
 		g.Expect(readyCondition.Reason).To(Equal(kustomizev1.ReconciliationFailedReason))
-		g.Expect(readyCondition.Message).To(ContainSubstring("%s/missing", id))
-		g.Expect(readyCondition.Message).To(ContainSubstring("unable to set ImpersonationConfig"))
+		g.Expect(readyCondition.Message).To(ContainSubstring("unable to set ImpersonationConfig for ServiceAccount 'missing'"))
+		g.Expect(readyCondition.Message).To(ContainSubstring(`"missing" not found`))
 	})
 
 	t.Run("reconciles impersonating service account", func(t *testing.T) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -209,6 +209,16 @@ func getEvents(objName string, annotations map[string]string) []corev1.Event {
 	return result
 }
 
+func createServiceAccount(name string, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return k8sClient.Create(context.Background(), sa)
+}
+
 func createNamespace(name string) error {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: name},

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/hashicorp/vault/api v1.6.0
 	github.com/onsi/gomega v1.19.0
 	github.com/ory/dockertest v3.3.5+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	go.mozilla.org/sops/v3 v3.7.3
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d
@@ -184,7 +185,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect


### PR DESCRIPTION
This PR adds a preliminary check on existence of the `ServiceAccount` to be impersonated on reconciliation, during the RESTClient `Config` setup.
The `ImpersonationConfig` with SA User was previously set on RESTclient Config no matter if the `ServiceAccount` exists.

This check avoids consequent otherwise failure for missing privileges on the missing SA's User, and improves error explanation.

Moreover, tests are updated accordingly.

Fixes #682.