### PR TITLE
[RFC-0003] Add support for OCIRepository sources

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,6 +144,11 @@ jobs:
           kubectl -n impersonation wait kustomizations/podinfo --for=condition=ready --timeout=4m
           kubectl -n impersonation delete kustomizations/podinfo
           until kubectl -n impersonation get deploy/podinfo 2>&1 | grep NotFound ; do sleep 2; done
+      - name: Run OCI tests
+        run: |
+          kubectl create ns oci
+          kubectl -n oci apply -f ./config/testdata/oci
+          kubectl -n oci wait kustomizations/oci --for=condition=ready --timeout=4m
       - name: Run CRDs + CRs tests
         run: |
           kubectl -n kustomize-system apply -f ./config/testdata/crds-crs
@@ -162,5 +167,7 @@ jobs:
           kubectl -n kustomize-system get gitrepositories -oyaml
           kubectl -n kustomize-system get kustomizations -oyaml
           kubectl -n kustomize-system get all
+          kubectl -n oci get ocirepository/oci -oyaml
+          kubectl -n oci get kustomization/oci -oyaml
           kubectl -n kustomize-system logs deploy/source-controller
           kubectl -n kustomize-system logs deploy/kustomize-controller

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # vendor/
 bin/
 config/release/
+config/crd/bases/ocirepositories.yaml
 config/crd/bases/gitrepositories.yaml
 config/crd/bases/buckets.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ run: generate fmt vet manifests
 download-crd-deps:
 	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml > config/crd/bases/gitrepositories.yaml
 	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml > config/crd/bases/buckets.yaml
+	curl -s https://raw.githubusercontent.com/fluxcd/source-controller/${SOURCE_VER}/config/crd/bases/source.toolkit.fluxcd.io_ocirepositories.yaml > config/crd/bases/ocirepositories.yaml
 
 # Install CRDs into a cluster
 install: manifests

--- a/api/v1beta2/reference_types.go
+++ b/api/v1beta2/reference_types.go
@@ -26,7 +26,7 @@ type CrossNamespaceSourceReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind of the referent.
-	// +kubebuilder:validation:Enum=GitRepository;Bucket
+	// +kubebuilder:validation:Enum=OCIRepository;GitRepository;Bucket
 	// +required
 	Kind string `json:"kind"`
 

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -942,6 +942,7 @@ spec:
                   kind:
                     description: Kind of the referent.
                     enum:
+                    - OCIRepository
                     - GitRepository
                     - Bucket
                     type: string

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kustomize-system
 resources:
-- https://github.com/fluxcd/source-controller/releases/download/v0.25.9/source-controller.crds.yaml
-- https://github.com/fluxcd/source-controller/releases/download/v0.25.9/source-controller.deployment.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.26.0/source-controller.crds.yaml
+- https://github.com/fluxcd/source-controller/releases/download/v0.26.0/source-controller.deployment.yaml
 - ../crd
 - ../rbac
 - ../manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,7 @@ rules:
   resources:
   - buckets
   - gitrepositories
+  - ocirepositories
   verbs:
   - get
   - list
@@ -67,5 +68,6 @@ rules:
   resources:
   - buckets/status
   - gitrepositories/status
+  - ocirepositories/status
   verbs:
   - get

--- a/config/testdata/oci/podinfo.yaml
+++ b/config/testdata/oci/podinfo.yaml
@@ -1,0 +1,37 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: oci
+  namespace: oci
+spec:
+  interval: 10m
+  url: oci://ghcr.io/stefanprodan/manifests/podinfo
+  ref:
+    tag: "6.1.6"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: oci
+  namespace: oci
+spec:
+  targetNamespace: oci
+  interval: 10m
+  path: "./kustomize"
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: oci
+  wait: true
+  timeout: 2m
+  patches:
+    - patch: |-
+        apiVersion: autoscaling/v2beta2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: podinfo
+        spec:
+          minReplicas: 1
+      target:
+        name: podinfo
+        kind: HorizontalPodAutoscaler

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -149,8 +149,9 @@ changes, it generates a Kubernetes event that triggers a kustomize build and app
 
 Source supported types:
 
-* [GitRepository](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1beta1/gitrepositories.md)
-* [Bucket](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1beta1/buckets.md)
+* [GitRepository](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1beta2/gitrepositories.md)
+* [OCIRepository](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1beta2/ocirepositories.md)
+* [Bucket](https://github.com/fluxcd/source-controller/blob/main/docs/spec/v1beta2/buckets.md)
 
 > **Note** that the source should contain the kustomization.yaml and all the
 > Kubernetes manifests and configuration files referenced in the kustomization.yaml.

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/fluxcd/pkg/ssa v0.17.0
 	github.com/fluxcd/pkg/testserver v0.2.0
 	github.com/fluxcd/pkg/untar v0.1.0
-	github.com/fluxcd/source-controller/api v0.25.9
+	github.com/fluxcd/source-controller/api v0.26.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/onsi/gomega v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/fluxcd/pkg/testserver v0.2.0 h1:Mj0TapmKaywI6Fi5wvt1LAZpakUHmtzWQpJNK
 github.com/fluxcd/pkg/testserver v0.2.0/go.mod h1:bgjjydkXsZTeFzjz9Cr4heGANr41uTB1Aj1Q5qzuYVk=
 github.com/fluxcd/pkg/untar v0.1.0 h1:k97V/xV5hFrAkIkVPuv5AVhyxh1ZzzAKba/lbDfGo6o=
 github.com/fluxcd/pkg/untar v0.1.0/go.mod h1:aGswNyzB1mlz/T/kpOS58mITBMxMKc9tlJBH037A2HY=
-github.com/fluxcd/source-controller/api v0.25.9 h1:hdaBYYNuW3qTcXRMfrxO5paK+UVFL9ApZS495nd7K2w=
-github.com/fluxcd/source-controller/api v0.25.9/go.mod h1:/e7YRDOqb8z8I3N8ifbDF1mknf8zFsoADtS/Q93iWPs=
+github.com/fluxcd/source-controller/api v0.26.0 h1:DOf9R7YLV0lNiIRnaYg5bh8fGbIB6zGbK5vFqejeSAk=
+github.com/fluxcd/source-controller/api v0.26.0/go.mod h1:1W0Xx/GpZ14Z/sOltxjsQKXeCv8zxAqSivbX9e4s+H8=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=


### PR DESCRIPTION
This PR implements OCIRepository reconciliation as described in the RFC [Flux OCI support for Kubernetes manifests](https://github.com/fluxcd/flux2/tree/main/rfcs/0003-kubernetes-oci).

Changes:
- allow `OCIRepository` to be specified in `sourceRef.kind`
- react to `OCIRepository` artifacts events
- add end-to-end test for OCI repositories
- update source-controller API to v0.26.0

Depends on: 
- https://github.com/fluxcd/source-controller/pull/788
- https://github.com/fluxcd/flux2/pull/2856