### PR TITLE
Fix job wait by adding polling options to impersonation client

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -85,6 +85,7 @@ type KustomizationReconciler struct {
 	EventRecorder         kuberecorder.EventRecorder
 	MetricsRecorder       *metrics.Recorder
 	StatusPoller          *polling.StatusPoller
+	PollingOpts           polling.Options
 	ControllerName        string
 	statusManager         string
 	NoCrossNamespaceRefs  bool
@@ -350,7 +351,7 @@ func (r *KustomizationReconciler) reconcile(
 	}
 
 	// setup the Kubernetes client for impersonation
-	impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount, r.KubeConfigOpts)
+	impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount, r.KubeConfigOpts, r.PollingOpts)
 	kubeClient, statusPoller, err := impersonation.GetClient(ctx)
 	if err != nil {
 		return kustomizev1.KustomizationNotReady(
@@ -931,7 +932,7 @@ func (r *KustomizationReconciler) finalize(ctx context.Context, kustomization ku
 		kustomization.Status.Inventory.Entries != nil {
 		objects, _ := ListObjectsInInventory(kustomization.Status.Inventory)
 
-		impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount, r.KubeConfigOpts)
+		impersonation := NewKustomizeImpersonation(kustomization, r.Client, r.StatusPoller, r.DefaultServiceAccount, r.KubeConfigOpts, r.PollingOpts)
 		if impersonation.CanFinalize(ctx) {
 			kubeClient, _, err := impersonation.GetClient(ctx)
 			if err != nil {

--- a/controllers/kustomization_impersonation.go
+++ b/controllers/kustomization_impersonation.go
@@ -41,6 +41,7 @@ type KustomizeImpersonation struct {
 	kustomization         kustomizev1.Kustomization
 	statusPoller          *polling.StatusPoller
 	defaultServiceAccount string
+	pollingOpts           polling.Options
 	kubeConfigOpts        runtimeClient.KubeConfigOptions
 }
 
@@ -50,13 +51,15 @@ func NewKustomizeImpersonation(
 	kubeClient client.Client,
 	statusPoller *polling.StatusPoller,
 	defaultServiceAccount string,
-	kubeConfigOpts runtimeClient.KubeConfigOptions) *KustomizeImpersonation {
+	kubeConfigOpts runtimeClient.KubeConfigOptions,
+	pollingOpts polling.Options) *KustomizeImpersonation {
 	return &KustomizeImpersonation{
 		defaultServiceAccount: defaultServiceAccount,
 		kustomization:         kustomization,
 		statusPoller:          statusPoller,
 		Client:                kubeClient,
 		kubeConfigOpts:        kubeConfigOpts,
+		pollingOpts:           pollingOpts,
 	}
 }
 
@@ -131,7 +134,7 @@ func (ki *KustomizeImpersonation) clientForServiceAccountOrDefault() (client.Cli
 		return nil, nil, err
 	}
 
-	statusPoller := polling.NewStatusPoller(client, restMapper, polling.Options{})
+	statusPoller := polling.NewStatusPoller(client, restMapper, ki.pollingOpts)
 	return client, statusPoller, err
 
 }
@@ -160,7 +163,7 @@ func (ki *KustomizeImpersonation) clientForKubeConfig(ctx context.Context) (clie
 		return nil, nil, err
 	}
 
-	statusPoller := polling.NewStatusPoller(client, restMapper, polling.Options{})
+	statusPoller := polling.NewStatusPoller(client, restMapper, ki.pollingOpts)
 
 	return client, statusPoller, err
 }

--- a/main.go
+++ b/main.go
@@ -141,6 +141,9 @@ func main() {
 	}
 
 	jobStatusReader := statusreaders.NewCustomJobStatusReader(mgr.GetRESTMapper())
+	pollingOpts := polling.Options{
+		CustomStatusReaders: []engine.StatusReader{jobStatusReader},
+	}
 	if err = (&controllers.KustomizationReconciler{
 		ControllerName:        controllerName,
 		DefaultServiceAccount: defaultServiceAccount,
@@ -151,9 +154,8 @@ func main() {
 		NoCrossNamespaceRefs:  aclOptions.NoCrossNamespaceRefs,
 		NoRemoteBases:         noRemoteBases,
 		KubeConfigOpts:        kubeConfigOpts,
-		StatusPoller: polling.NewStatusPoller(mgr.GetClient(), mgr.GetRESTMapper(), polling.Options{
-			CustomStatusReaders: []engine.StatusReader{jobStatusReader},
-		}),
+		PollingOpts:           pollingOpts,
+		StatusPoller:          polling.NewStatusPoller(mgr.GetClient(), mgr.GetRESTMapper(), pollingOpts),
 	}).SetupWithManager(mgr, controllers.KustomizationReconcilerOptions{
 		MaxConcurrentReconciles:   concurrent,
 		DependencyRequeueInterval: requeueDependency,


### PR DESCRIPTION
Fixes: #686 

Use polling options (such as the internal custom job statusreaders) when creating a new status poller.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>