### PR TITLE
Add file path to sops decryption errors

### DIFF
--- a/controllers/kustomization_decryptor.go
+++ b/controllers/kustomization_decryptor.go
@@ -621,7 +621,7 @@ func secureLoadKustomizationFile(root, path string) (*kustypes.Kustomization, er
 		},
 	}
 	if err := yaml.Unmarshal(data, &kus); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal kustomization file: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal kustomization file from '%s': %w", loadPath, err)
 	}
 	return &kus, nil
 }


### PR DESCRIPTION
If one of the `kustomization.yaml` files can't be unmarshal by the SOPS decryptor, users can't tell from the error message which file was at fault e.g.
```
error decrypting env sources: failed to unmarshal kustomization file: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch
```

This PR adds the file path to the error message.