### PR TITLE
Allow reordering of Kustomize resources

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -83,6 +83,7 @@ type KustomizationReconciler struct {
 	statusManager         string
 	NoCrossNamespaceRefs  bool
 	NoRemoteBases         bool
+	Reorder               string
 	DefaultServiceAccount string
 	KubeConfigOpts        runtimeClient.KubeConfigOptions
 }
@@ -596,6 +597,14 @@ func (r *KustomizationReconciler) generate(kustomization kustomizev1.Kustomizati
 	return gen.WriteFile(dirPath)
 }
 
+func (r *KustomizationReconciler) getFlagReorderOutput() bool {
+	if r.Reorder == "none" {
+		return false
+	} else {
+		return true
+	}
+}
+
 func (r *KustomizationReconciler) build(ctx context.Context, workDir string, kustomization kustomizev1.Kustomization, dirPath string) ([]byte, error) {
 	dec, cleanup, err := NewTempDecryptor(workDir, r.Client, kustomization)
 	if err != nil {
@@ -613,7 +622,7 @@ func (r *KustomizationReconciler) build(ctx context.Context, workDir string, kus
 		return nil, fmt.Errorf("error decrypting env sources: %w", err)
 	}
 
-	m, err := secureBuildKustomization(workDir, dirPath, !r.NoRemoteBases)
+	m, err := secureBuildKustomization(workDir, dirPath, !r.NoRemoteBases, r.getFlagReorderOutput())
 	if err != nil {
 		return nil, fmt.Errorf("kustomize build failed: %w", err)
 	}

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -244,11 +244,12 @@ func adaptSelector(selector *kustomize.Selector) (output *kustypes.Selector) {
 var kustomizeBuildMutex sync.Mutex
 
 // secureBuildKustomization wraps krusty.MakeKustomizer with the following settings:
+//  - specify resource sorting options
 //  - secure on-disk FS denying operations outside root
 //  - load files from outside the kustomization dir path
 //    (but not outside root)
 //  - disable plugins except for the builtin ones
-func secureBuildKustomization(root, dirPath string, allowRemoteBases bool) (_ resmap.ResMap, err error) {
+func secureBuildKustomization(root, dirPath string, allowRemoteBases bool, doLegacyResourceSort bool) (_ resmap.ResMap, err error) {
 	var fs filesys.FileSystem
 
 	// Create secure FS for root with or without remote base support
@@ -279,8 +280,9 @@ func secureBuildKustomization(root, dirPath string, allowRemoteBases bool) (_ re
 	}()
 
 	buildOptions := &krusty.Options{
-		LoadRestrictions: kustypes.LoadRestrictionsNone,
-		PluginConfig:     kustypes.DisabledPluginConfig(),
+		DoLegacyResourceSort: doLegacyResourceSort,
+		LoadRestrictions:     kustypes.LoadRestrictionsNone,
+		PluginConfig:         kustypes.DisabledPluginConfig(),
 	}
 
 	k := krusty.MakeKustomizer(buildOptions)

--- a/controllers/kustomization_generator_test.go
+++ b/controllers/kustomization_generator_test.go
@@ -26,14 +26,14 @@ func Test_secureBuildKustomization(t *testing.T) {
 	t.Run("remote build", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", true)
+		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", true, true)
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("no remote build", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", false)
+		_, err := secureBuildKustomization("testdata/remote", "testdata/remote", false, true)
 		g.Expect(err).To(HaveOccurred())
 	})
 }
@@ -42,11 +42,11 @@ func Test_secureBuildKustomization_panic(t *testing.T) {
 	t.Run("build panic", func(t *testing.T) {
 		g := NewWithT(t)
 
-		_, err := secureBuildKustomization("testdata/panic", "testdata/panic", false)
+		_, err := secureBuildKustomization("testdata/panic", "testdata/panic", false, true)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("recovered from kustomize build panic"))
 		// Run again to ensure the lock is released
-		_, err = secureBuildKustomization("testdata/panic", "testdata/panic", false)
+		_, err = secureBuildKustomization("testdata/panic", "testdata/panic", false, true)
 		g.Expect(err).To(HaveOccurred())
 	})
 }
@@ -54,6 +54,6 @@ func Test_secureBuildKustomization_panic(t *testing.T) {
 func Test_secureBuildKustomization_rel_basedir(t *testing.T) {
 	g := NewWithT(t)
 
-	_, err := secureBuildKustomization("testdata/relbase", "testdata/relbase/clusters/staging/flux-system", false)
+	_, err := secureBuildKustomization("testdata/relbase", "testdata/relbase/clusters/staging/flux-system", false, true)
 	g.Expect(err).ToNot(HaveOccurred())
 }

--- a/main.go
+++ b/main.go
@@ -48,7 +48,9 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const controllerName = "kustomize-controller"
+const (
+	controllerName = "kustomize-controller"
+)
 
 var (
 	scheme   = runtime.NewScheme()
@@ -80,6 +82,7 @@ func main() {
 		noRemoteBases         bool
 		httpRetry             int
 		defaultServiceAccount string
+		reorder               string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -93,6 +96,11 @@ func main() {
 		"Disallow remote bases usage in Kustomize overlays. When this flag is enabled, all resources must refer to local files included in the source artifact.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
 	flag.StringVar(&defaultServiceAccount, "default-service-account", "", "Default service account used for impersonation.")
+	flag.StringVar(&reorder, "reorder", "legacy",
+		"Reorder the resources just before output. "+
+			"Use 'legacy' to apply a legacy reordering "+
+			"(Namespaces first, Webhooks last, etc). "+
+			"Use 'none' to suppress a final reordering.")
 	clientOptions.BindFlags(flag.CommandLine)
 	logOptions.BindFlags(flag.CommandLine)
 	leaderElectionOptions.BindFlags(flag.CommandLine)
@@ -147,6 +155,7 @@ func main() {
 	if err = (&controllers.KustomizationReconciler{
 		ControllerName:        controllerName,
 		DefaultServiceAccount: defaultServiceAccount,
+		Reorder:               reorder,
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		EventRecorder:         eventRecorder,

--- a/main.go
+++ b/main.go
@@ -48,9 +48,7 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const (
-	controllerName = "kustomize-controller"
-)
+const controllerName = "kustomize-controller"
 
 var (
 	scheme   = runtime.NewScheme()


### PR DESCRIPTION
The Kustomize CLI command allows you to specify whether you want to use the 'legacy' sorting system of resources or none, this PR introduces this option into the FluxCD kustomize controller.