### PR TITLE
Update doc on target namespace

### DIFF
--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -630,7 +630,7 @@ spec:
   targetNamespace: test
 ```
 
-While `targetNamespace` is optional, if `targetNamespace` exists, then the namespace pointed to by the `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
+While the field `targetNamespace` in Kustomization is optional, if this field exists, then the k8s namespace pointed to by `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
 
 ### Patches
 

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -630,7 +630,7 @@ spec:
   targetNamespace: test
 ```
 
-The `targetNamespace` is expected to exist.
+While `targetNamespace` is optional, if `targetNamespace` exists, then the namespace pointed to by the `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
 
 ### Patches
 

--- a/docs/spec/v1beta1/kustomization.md
+++ b/docs/spec/v1beta1/kustomization.md
@@ -630,7 +630,7 @@ spec:
   targetNamespace: test
 ```
 
-While the field `targetNamespace` in Kustomization is optional, if this field exists, then the k8s namespace pointed to by `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
+While the field `targetNamespace` in a Kustomization is optional, if this field is non-empty then the Kubernetes namespace pointed to by `targetNamespace` must exist prior to the Kustomization being applied, kustomize-controller will not create the namespace.
 
 ### Patches
 

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -569,7 +569,7 @@ spec:
   targetNamespace: test
 ```
 
-The `targetNamespace` is expected to exist.
+ While `targetNamespace` is optional, if `targetNamespace` exists, then the namespace pointed to by the `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
 
 ### Patches
 

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -569,7 +569,7 @@ spec:
   targetNamespace: test
 ```
 
-While the field `targetNamespace` in Kustomization is optional, if this field exists, then the k8s namespace pointed to by `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
+While the field `targetNamespace` in a Kustomization is optional, if this field is non-empty then the Kubernetes namespace pointed to by `targetNamespace` must exist prior to the Kustomization being applied, kustomize-controller will not create the namespace.
 
 ### Patches
 

--- a/docs/spec/v1beta2/kustomization.md
+++ b/docs/spec/v1beta2/kustomization.md
@@ -569,7 +569,7 @@ spec:
   targetNamespace: test
 ```
 
- While `targetNamespace` is optional, if `targetNamespace` exists, then the namespace pointed to by the `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
+While the field `targetNamespace` in Kustomization is optional, if this field exists, then the k8s namespace pointed to by `targetNamespace` is expected to exist, kustomize-controller will not create it otherwise.
 
 ### Patches
 


### PR DESCRIPTION
`targetNamespace` for a kustomization CRD is optional. The doc seemed slightly misleading, adding more details to clarify the doc.

Relevant discussion: https://cloud-native.slack.com/archives/CLAJ40HV3/p1661003204571329