### PR TITLE
Reconcile Kubernetes class type objects in a dedicated stage

### DIFF
--- a/controllers/kustomization_fetcher_test.go
+++ b/controllers/kustomization_fetcher_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,10 +136,8 @@ stringData:
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
 			ready := apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
-			return ready.Reason == meta.ProgressingReason
+			return strings.Contains(ready.Message, "artifact not found")
 		}, timeout, time.Second).Should(BeTrue())
-
-		g.Expect(apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition).Message).To(ContainSubstring("artifact not found"))
 	})
 
 	t.Run("recovers after not found errors", func(t *testing.T) {


### PR DESCRIPTION
This PR adds a new stage to the server-side apply where the controller reconciles the Kubernetes Class types (RuntimeClass, PriorityClass, StorageClass, VolumeSnapshotClass, IngressClass, GatewayClass, ClusterClass, etc) after CRDs, but before any other resource type. This allows users to bundle Class types with their consumers, e.g. ClusterClass and Cluster, or IngressClass and Ingress.

Fix: #719 

PS. This PR also fixes a flaky test.