### PR TITLE
Sort SOPS masterkeys so offline decrypt methods are tried first

### DIFF
--- a/internal/sops/keyservice/keyservice.go
+++ b/internal/sops/keyservice/keyservice.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 The Flux authors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package keyservice
+
+import (
+	"go.mozilla.org/sops/v3/age"
+	"go.mozilla.org/sops/v3/keys"
+	"go.mozilla.org/sops/v3/pgp"
+)
+
+// IsOfflineMethod returns true for offline decrypt methods or false otherwise
+func IsOfflineMethod(mk keys.MasterKey) bool {
+	switch mk.(type) {
+	case *pgp.MasterKey, *age.MasterKey:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This is to sort master keys so PGP/age keys appear before the others and being used first. Thus if one of local methods is successful we avoid going to remote KMS/HCVault which may not be accessible from specific network and cause unnecessary timeouts or have some other cost.

Originally I've submitted [PR to SOPS project ](https://github.com/mozilla/sops/pull/1121) as solution for [this issue](https://github.com/mozilla/sops/issues/305), but as it seems it could be a while till that PR is reviewed and new version is released. And since kustomize-controller has some internal SOPS implementation same thing could be achieved before passing data to SOPS.