### PR TITLE
api: add custom validation for v1.Duration types

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -47,12 +47,16 @@ type KustomizationSpec struct {
 	Decryption *Decryption `json:"decryption,omitempty"`
 
 	// The interval at which to reconcile the Kustomization.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
 	// The interval at which to retry a previously failed reconciliation.
 	// When not specified, the controller uses the KustomizationSpec.Interval
 	// value to retry failures.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	RetryInterval *metav1.Duration `json:"retryInterval,omitempty"`
 
@@ -130,6 +134,8 @@ type KustomizationSpec struct {
 
 	// Timeout for validation, apply and health checking operations.
 	// Defaults to 'Interval' duration.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -689,6 +689,7 @@ spec:
                 type: array
               interval:
                 description: The interval at which to reconcile the Kustomization.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               kubeConfig:
                 description: The KubeConfig for reconciling the Kustomization on a
@@ -928,6 +929,7 @@ spec:
                 description: The interval at which to retry a previously failed reconciliation.
                   When not specified, the controller uses the KustomizationSpec.Interval
                   value to retry failures.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               serviceAccountName:
                 description: The name of the Kubernetes service account to impersonate
@@ -972,6 +974,7 @@ spec:
               timeout:
                 description: Timeout for validation, apply and health checking operations.
                   Defaults to 'Interval' duration.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                 type: string
               validation:
                 description: 'Deprecated: Not used in v1beta2.'


### PR DESCRIPTION
To solve discrepancies between parsing versus validation.

xref: https://github.com/kubernetes/apimachinery/issues/131