### PR TITLE
Build with Go 1.19

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - id: go-env
       run: |
         echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
@@ -29,7 +29,7 @@ COPY internal/ internal/
 
 # build
 ENV CGO_ENABLED=0
-RUN xx-go build -a -o kustomize-controller main.go
+RUN xx-go build -trimpath -a -o kustomize-controller main.go
 
 FROM alpine:3.16
 

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ api-docs: gen-crd-api-reference-docs
 
 # Run go mod tidy
 tidy:
-	cd api; rm -f go.sum; go mod tidy -compat=1.18
-	rm -f go.sum; go mod tidy -compat=1.18
+	cd api; rm -f go.sum; go mod tidy -compat=1.19
+	rm -f go.sum; go mod tidy -compat=1.19
 
 # Run go fmt against code
 fmt:
@@ -140,7 +140,7 @@ docker-deploy:
 CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
 
 # Find or download gen-crd-api-reference-docs
 GEN_CRD_API_REFERENCE_DOCS = $(GOBIN)/gen-crd-api-reference-docs

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: kustomizations.kustomize.toolkit.fluxcd.io
 spec:
@@ -441,14 +440,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -1003,14 +1000,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    \n \ttype FooStatus struct{ \t    // Represents the observations
-                    of a foo's current state. \t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
-                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
-                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
-                    \t}"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/controllers/kustomization_generator.go
+++ b/controllers/kustomization_generator.go
@@ -244,10 +244,10 @@ func adaptSelector(selector *kustomize.Selector) (output *kustypes.Selector) {
 var kustomizeBuildMutex sync.Mutex
 
 // secureBuildKustomization wraps krusty.MakeKustomizer with the following settings:
-//  - secure on-disk FS denying operations outside root
-//  - load files from outside the kustomization dir path
-//    (but not outside root)
-//  - disable plugins except for the builtin ones
+//   - secure on-disk FS denying operations outside root
+//   - load files from outside the kustomization dir path
+//     (but not outside root)
+//   - disable plugins except for the builtin ones
 func secureBuildKustomization(root, dirPath string, allowRemoteBases bool) (_ resmap.ResMap, err error) {
 	var fs filesys.FileSystem
 

--- a/internal/sops/azkv/config.go
+++ b/internal/sops/azkv/config.go
@@ -52,14 +52,14 @@ type AZConfig struct {
 // TokenFromAADConfig attempts to construct a Token using the AADConfig values.
 // It detects credentials in the following order:
 //
-//  - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
-//    `clientSecret` fields are found.
-//  - azidentity.ClientCertificateCredential when `tenantId`,
-//    `clientCertificate` (and optionally `clientCertificatePassword`) fields
-//    are found.
-//  - azidentity.ClientSecretCredential when AZConfig fields are found.
-//  - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
-//    field but no `tenantId` is found.
+//   - azidentity.ClientSecretCredential when `tenantId`, `clientId` and
+//     `clientSecret` fields are found.
+//   - azidentity.ClientCertificateCredential when `tenantId`,
+//     `clientCertificate` (and optionally `clientCertificatePassword`) fields
+//     are found.
+//   - azidentity.ClientSecretCredential when AZConfig fields are found.
+//   - azidentity.ManagedIdentityCredential for a User ID, when a `clientId`
+//     field but no `tenantId` is found.
 //
 // If no set of credentials is found or the azcore.TokenCredential can not be
 // created, an error is returned.


### PR DESCRIPTION
Changes:
- Update Go to 1.19 in CI
- Use Go 1.19 in base image
- Update controller-gen v0.8.0 (v0.7 fails with Go 1.19) and regenerate manifests
