### PR TITLE
Support alternative kustomization file names

### DIFF
--- a/controllers/kustomization_controller.go
+++ b/controllers/kustomization_controller.go
@@ -592,8 +592,8 @@ func (r *KustomizationReconciler) getSource(ctx context.Context, kustomization k
 }
 
 func (r *KustomizationReconciler) generate(kustomization kustomizev1.Kustomization, workDir string, dirPath string) error {
-	gen := NewGenerator(workDir, kustomization)
-	return gen.WriteFile(dirPath)
+	_, err := NewGenerator(workDir, kustomization).WriteFile(dirPath)
+	return err
 }
 
 func (r *KustomizationReconciler) build(ctx context.Context, workDir string, kustomization kustomizev1.Kustomization, dirPath string) ([]byte, error) {

--- a/controllers/kustomization_generator_test.go
+++ b/controllers/kustomization_generator_test.go
@@ -17,8 +17,16 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/otiai10/copy"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+
+	"github.com/fluxcd/kustomize-controller/api/v1beta2"
+	"github.com/fluxcd/pkg/apis/kustomize"
 	. "github.com/onsi/gomega"
 )
 
@@ -56,4 +64,68 @@ func Test_secureBuildKustomization_rel_basedir(t *testing.T) {
 
 	_, err := secureBuildKustomization("testdata/relbase", "testdata/relbase/clusters/staging/flux-system", false)
 	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestGeneratorWriteFile(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{
+			name: "detects kustomization.yml",
+			dir:  "yml",
+		},
+		{
+			name: "detects Kustomization",
+			dir:  "Kustomization",
+		},
+		{
+			name: "detects kustomization.yaml",
+			dir:  "yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			tmpDir := t.TempDir()
+			g.Expect(copy.Copy("./testdata/different-filenames", tmpDir)).To(Succeed())
+			ks := v1beta2.Kustomization{
+				Spec: v1beta2.KustomizationSpec{
+					PatchesStrategicMerge: []apiextv1.JSON{
+						{
+							Raw: []byte(`{"kind":"Deployment","apiVersion":"apps/v1","metadata":{"name":"podinfo","labels":{"patch4":"strategic-merge"}}}`),
+						},
+					},
+					Patches: []kustomize.Patch{
+						{
+							Patch: `- op: add
+  path: /metadata/labels/patch1
+  value: inline-json`,
+							Target: kustomize.Selector{
+								LabelSelector: "app=podinfo",
+							},
+						},
+					},
+					PatchesJSON6902: []kustomize.JSON6902Patch{
+						{
+							Patch: []kustomize.JSON6902{
+								{Op: "add", Path: "/metadata/labels/patch3", Value: &apiextv1.JSON{Raw: []byte(`"json6902"`)}},
+							},
+						},
+					},
+				},
+			}
+			kfile, err := NewGenerator(filepath.Join(tmpDir, tt.dir), ks).WriteFile(filepath.Join(tmpDir, tt.dir))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			kfileYAML, err := os.ReadFile(kfile)
+			g.Expect(err).ToNot(HaveOccurred())
+			var k kustypes.Kustomization
+			g.Expect(k.Unmarshal(kfileYAML)).To(Succeed())
+			g.Expect(k.Patches).To(HaveLen(1), "unexpected number of patches in kustomization file")
+			g.Expect(k.PatchesStrategicMerge).To(HaveLen(1), "unexpected number of strategic merge patches in kustomization file")
+			g.Expect(k.PatchesJson6902).To(HaveLen(1), "unexpected number of RFC 6902 patches in kustomization file")
+		})
+	}
 }

--- a/controllers/testdata/different-filenames/Kustomization/Kustomization
+++ b/controllers/testdata/different-filenames/Kustomization/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml

--- a/controllers/testdata/different-filenames/Kustomization/deployment.yaml
+++ b/controllers/testdata/different-filenames/Kustomization/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+  labels:
+    app: podinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      labels:
+        app: podinfo
+    spec:
+      containers:
+        - name: podinfo
+          image: podinfo

--- a/controllers/testdata/different-filenames/yaml/deployment.yaml
+++ b/controllers/testdata/different-filenames/yaml/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+  labels:
+    app: podinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      labels:
+        app: podinfo
+    spec:
+      containers:
+        - name: podinfo
+          image: podinfo

--- a/controllers/testdata/different-filenames/yaml/kustomization.yaml
+++ b/controllers/testdata/different-filenames/yaml/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml

--- a/controllers/testdata/different-filenames/yml/deployment.yaml
+++ b/controllers/testdata/different-filenames/yml/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+  labels:
+    app: podinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      labels:
+        app: podinfo
+    spec:
+      containers:
+        - name: podinfo
+          image: podinfo

--- a/controllers/testdata/different-filenames/yml/kustomization.yml
+++ b/controllers/testdata/different-filenames/yml/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/hashicorp/vault/api v1.8.0
 	github.com/onsi/gomega v1.20.2
 	github.com/ory/dockertest v3.3.5+incompatible
+	github.com/otiai10/copy v1.7.0
 	github.com/spf13/pflag v1.0.5
 	go.mozilla.org/sops/v3 v3.7.3
 	golang.org/x/net v0.0.0-20220927171203-f486391704dc
@@ -48,6 +49,7 @@ require (
 	sigs.k8s.io/cli-utils v0.33.0
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/kustomize/api v0.12.1
+	sigs.k8s.io/kustomize/kyaml v0.13.9
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -228,6 +230,5 @@ require (
 	k8s.io/kubectl v0.24.0 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -688,6 +688,13 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
`KustomizeGenerator.WriteFile` now detects alternative kustomization
file names such as `kustomization.yml` and `Kustomization`.

closes #737

