### PR TITLE
api: allow configuration of `h` unit for timeouts

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -134,7 +134,7 @@ type KustomizationSpec struct {
 	// Timeout for validation, apply and health checking operations.
 	// Defaults to 'Interval' duration.
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -973,7 +973,7 @@ spec:
               timeout:
                 description: Timeout for validation, apply and health checking operations.
                   Defaults to 'Interval' duration.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               validation:
                 description: 'Deprecated: Not used in v1beta2.'


### PR DESCRIPTION
To allow waiting for `HelmRelease` resources with an exceptionally high timeout of `1h` or more.

Related to: https://github.com/fluxcd/helm-controller/pull/549