### PR TITLE
build: Bump gpg to alpine's edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ RUN xx-go build -trimpath -a -o kustomize-controller main.go
 
 FROM alpine:3.16
 
-RUN apk add --no-cache ca-certificates tini git openssh-client gnupg
+# Uses GnuPG from edge to patch CVE-2022-3515.
+RUN apk add --no-cache ca-certificates tini git openssh-client && \
+	apk add --no-cache gnupg --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY --from=builder /workspace/kustomize-controller /usr/local/bin/
 


### PR DESCRIPTION
LibKSBA is a dependency to GnuPG, which has a CVE that is yet to be patched on Alpine's stable channel. This PR installs GnuPG from the edge channel, and should be reverted once libksba's version 1.6.2 is in main.

https://pkgs.alpinelinux.org/packages?name=libksba&branch=edge
https://gnupg.org/blog/20221017-pepe-left-the-ksba.html
