### PR TITLE
Remove nsswitch.conf creation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,6 @@ RUN apk add --no-cache ca-certificates tini git openssh-client && \
 
 COPY --from=builder /workspace/kustomize-controller /usr/local/bin/
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
 USER 65534:65534
 
 ENV GNUPGHOME=/tmp


### PR DESCRIPTION
Creating a minimal nsswitch.conf in Alpine is no longer necessary due to https://git.alpinelinux.org/aports/commit/?id=348653a9ba0701e8e968b3344e72313a9ef334e4