### PR TITLE
Enable kstatus checks

### DIFF
--- a/controllers/kustomization_force_test.go
+++ b/controllers/kustomization_force_test.go
@@ -137,7 +137,7 @@ stringData:
 		}, timeout, time.Second).Should(BeTrue())
 		logStatus(t, resultK)
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 
 		t.Run("emits validation error event", func(t *testing.T) {
 			events := getEvents(resultK.GetName(), map[string]string{"kustomize.toolkit.fluxcd.io/revision": revision})
@@ -166,7 +166,7 @@ stringData:
 		}, timeout, time.Second).Should(BeTrue())
 		logStatus(t, resultK)
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 
 		g.Expect(apimeta.IsStatusConditionTrue(resultK.Status.Conditions, kustomizev1.HealthyCondition)).To(BeTrue())
 	})

--- a/controllers/kustomization_wait_test.go
+++ b/controllers/kustomization_wait_test.go
@@ -131,7 +131,7 @@ parameters:
 
 		g.Expect(resultK.Status.ObservedGeneration).To(BeIdenticalTo(resultK.Generation))
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 	})
 
 	t.Run("reports progressing status", func(t *testing.T) {
@@ -164,6 +164,7 @@ parameters:
 			g.Expect(conditions.GetMessage(resultK, c)).To(ContainSubstring(expectedMessage))
 			g.Expect(conditions.GetObservedGeneration(resultK, c)).To(BeIdenticalTo(resultK.Generation))
 		}
+		kstatusInProgressCheck.CheckErr(ctx, resultK)
 	})
 
 	t.Run("reports unhealthy status", func(t *testing.T) {
@@ -186,7 +187,7 @@ parameters:
 		g.Expect(resultK.Status.LastHandledReconcileAt).To(BeIdenticalTo(reconcileRequestAt))
 		g.Expect(resultK.Status.ObservedGeneration).To(BeIdenticalTo(resultK.Generation - 1))
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 	})
 
 	t.Run("emits unhealthy event", func(t *testing.T) {
@@ -222,7 +223,7 @@ parameters:
 
 		g.Expect(resultK.Status.ObservedGeneration).To(BeIdenticalTo(resultK.Generation))
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 	})
 
 	t.Run("emits recovery event", func(t *testing.T) {
@@ -252,7 +253,7 @@ parameters:
 
 		g.Expect(resultK.Status.LastAttemptedRevision).To(BeIdenticalTo(resultK.Status.LastAppliedRevision))
 
-		//kstatusCheck.CheckErr(ctx, resultK)
+		kstatusCheck.CheckErr(ctx, resultK)
 	})
 
 	t.Run("emits event for the new revision", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v0.18.0
 	github.com/fluxcd/pkg/http/fetch v0.3.0
 	github.com/fluxcd/pkg/kustomize v0.12.0
-	github.com/fluxcd/pkg/runtime v0.24.0
+	github.com/fluxcd/pkg/runtime v0.26.0
 	github.com/fluxcd/pkg/ssa v0.22.0
 	github.com/fluxcd/pkg/tar v0.2.0
 	github.com/fluxcd/pkg/testserver v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/fluxcd/pkg/http/fetch v0.3.0 h1:/mLj0IzTx+GhR09etzMJsBoNQ0qeOx9cSdeUg
 github.com/fluxcd/pkg/http/fetch v0.3.0/go.mod h1:dHTDYIeL0ZAQ9mHM6ZS4VProxho+Atm73MHJ55yj0Sg=
 github.com/fluxcd/pkg/kustomize v0.12.0 h1:4MQdbP3M8NTIcr8TgNMxRCN+2xZoMWtCDDS3RiOT+8M=
 github.com/fluxcd/pkg/kustomize v0.12.0/go.mod h1:awHID4OKe2/WAfTFg4u0fURXZPUkrIslSZNSPX9MEFQ=
-github.com/fluxcd/pkg/runtime v0.24.0 h1:rQmm5Xq8K7f8xcPj1oNOInM1x4YwmgTucZJOP51Xmr4=
-github.com/fluxcd/pkg/runtime v0.24.0/go.mod h1:I2T+HWVNzX0cxm9TgH+SVNHTwqlmEDiSke43JXsq9iY=
+github.com/fluxcd/pkg/runtime v0.26.0 h1:j78f52xzpbR8xOvvemGwbGt4BLxpn9FOzim5tngOYvo=
+github.com/fluxcd/pkg/runtime v0.26.0/go.mod h1:I2T+HWVNzX0cxm9TgH+SVNHTwqlmEDiSke43JXsq9iY=
 github.com/fluxcd/pkg/ssa v0.22.0 h1:HvJTuiYLZMxCjin7bAqBgnc2RjSqEfYrMbV5yINoM64=
 github.com/fluxcd/pkg/ssa v0.22.0/go.mod h1:QND0ZNOQ5EzFxoNKfjUxE9J46AbRK3WKF8YkURwbVg0=
 github.com/fluxcd/pkg/tar v0.2.0 h1:HEUHgONQYsJGeZZ4x6h5nQU9Aox1I4T3bOp1faWTqf8=


### PR DESCRIPTION
Update `fluxcd/pkg/runtime` to v0.25.0 which has the new kstatus checker enhancements.
Enable previous kstatus checks and introduce kstatus in-progress checker for testing in-progress status of objects.