### PR TITLE
Update Alpine to 3.17

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,10 +42,10 @@ jobs:
         with:
           go-version: 1.19.x
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: helm/kind-action@v1.5.0
         with:
-          version: v0.11.1
-          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          version: v0.17.0
+          cluster_name: kind
       - name: Setup Kustomize
         uses: fluxcd/pkg//actions/kustomize@main
       - name: Setup Kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -trimpath -a -o kustomize-controller main.go
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 # Uses GnuPG from edge to patch CVE-2022-3515.
 RUN apk add --no-cache ca-certificates tini git openssh-client && \

--- a/config/testdata/impersonation/test.yaml
+++ b/config/testdata/impersonation/test.yaml
@@ -42,7 +42,7 @@ spec:
   interval: 5m
   url: https://github.com/stefanprodan/podinfo
   ref:
-    tag: "5.0.3"
+    tag: "6.3.0"
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -60,7 +60,7 @@ spec:
     name: podinfo
   patches:
     - patch: |
-        apiVersion: autoscaling/v2beta2
+        apiVersion: autoscaling/v2
         kind: HorizontalPodAutoscaler
         metadata:
           name: podinfo

--- a/config/testdata/oci/podinfo.yaml
+++ b/config/testdata/oci/podinfo.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 10m
   url: oci://ghcr.io/stefanprodan/manifests/podinfo
   ref:
-    tag: "6.1.6"
+    tag: "6.3.0"
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -26,7 +26,7 @@ spec:
   timeout: 2m
   patches:
     - patch: |-
-        apiVersion: autoscaling/v2beta2
+        apiVersion: autoscaling/v2
         kind: HorizontalPodAutoscaler
         metadata:
           name: podinfo

--- a/controllers/kustomization_dependson_test.go
+++ b/controllers/kustomization_dependson_test.go
@@ -57,10 +57,10 @@ metadata:
 data:
   key: "%[2]s"
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: "v2beta2-%[1]s"
+  name: "v2-%[1]s"
   namespace: "%[2]s"
 spec:
   scaleTargetRef:


### PR DESCRIPTION
Bump Alpine version to fix the following OS CVEs:
- CVE-2022-41903
- CVE-2022-3515
- CVE-2022-47629 
- CVE-2022-43551
- CVE-2022-23521 
- CVE-2022-43552

An official image is available with zero CVEs at: `ghcr.io/fluxcd/kustomize-controller:rc-949873ae`. To deploy this image on clusters bootstrapped by Flux see https://fluxcd.io/flux/cheatsheets/bootstrap/#test-release-candidates

Ref: https://github.com/fluxcd/flux2/issues/3515