### PR TITLE
kstatus: allow disabling of caching cluster reader

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -27,12 +27,23 @@ const (
 	// When enabled, it will cache both object types, resulting in increased
 	// memory usage and cluster-wide RBAC permissions (list and watch).
 	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
+
+	// DisableStatusPollerCache controls whether the status polling cache
+	// should be disabled.
+	//
+	// This may be useful when the controller is running in a cluster with a
+	// large number of resources, as it will potentially reduce the amount of
+	// memory used by the controller.
+	DisableStatusPollerCache = "DisableStatusPollerCache"
 )
 
 var features = map[string]bool{
 	// CacheSecretsAndConfigMaps
 	// opt-in from v0.33
 	CacheSecretsAndConfigMaps: false,
+	// DisableStatusPollerCache
+	// opt-in from v0.35
+	DisableStatusPollerCache: false,
 }
 
 // FeatureGates contains a list of all supported feature gates and

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/clusterreader"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -164,6 +165,9 @@ func main() {
 	jobStatusReader := statusreaders.NewCustomJobStatusReader(mgr.GetRESTMapper())
 	pollingOpts := polling.Options{
 		CustomStatusReaders: []engine.StatusReader{jobStatusReader},
+	}
+	if ok, _ := features.Enabled(features.DisableStatusPollerCache); ok {
+		pollingOpts.ClusterReaderFactory = engine.ClusterReaderFactoryFunc(clusterreader.NewDirectClusterReader)
 	}
 	if err = (&controllers.KustomizationReconciler{
 		ControllerName:        controllerName,


### PR DESCRIPTION
This commit allows the disabling of the caching cluster reader used by
the status poller while waiting and/or checking the health of resources.
Potentially reducing the memory usage of the controller on large scale
clusters, at the cost of an increase in direct API calls.

The feature can be enabled using
`--feature-gates=DisableStatusPollerCache=true`.

Potentially helps aid scenario described in #801