### PR TITLE
Use `logger.SetLogger` to also configure `klog`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v0.19.1
 	github.com/fluxcd/pkg/http/fetch v0.3.1
 	github.com/fluxcd/pkg/kustomize v0.13.2
-	github.com/fluxcd/pkg/runtime v0.29.0
+	github.com/fluxcd/pkg/runtime v0.31.0
 	github.com/fluxcd/pkg/ssa v0.24.1
 	github.com/fluxcd/pkg/tar v0.2.0
 	github.com/fluxcd/pkg/testserver v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/fluxcd/pkg/http/fetch v0.3.1 h1:GEkPN4Ap9OQzV1vjn3ioom2GFM+TtYWwWrG6p
 github.com/fluxcd/pkg/http/fetch v0.3.1/go.mod h1:8w2CdIPIio8zvM4xZMiHXVS1axUsY1hPWIcqKIXg6JE=
 github.com/fluxcd/pkg/kustomize v0.13.2 h1:isA9yi+m7sSIxdTrFR1U7+LyS2BraG07ZkKLHw3bnGo=
 github.com/fluxcd/pkg/kustomize v0.13.2/go.mod h1:1H9qednPxL/JvZE5at/f6wVHTH4WmxJYqfgVOZJ3uAk=
-github.com/fluxcd/pkg/runtime v0.29.0 h1:/BDitj/y5shWqczECCiZFsEm9FH7do4VBgMHBiRiol0=
-github.com/fluxcd/pkg/runtime v0.29.0/go.mod h1:NrBONYHO5Piuzm6Y7QTS3cJRlgkgsDPn2EKB6gJ4BQw=
+github.com/fluxcd/pkg/runtime v0.31.0 h1:addyXaANHl/A68bEjCbiR4HzcFKgfXv1eaG7B7ZHxOo=
+github.com/fluxcd/pkg/runtime v0.31.0/go.mod h1:toGOOubMo4ZC1aWhB8C3drdTglr1/A1dETeNwjiIv0g=
 github.com/fluxcd/pkg/ssa v0.24.1 h1:0dn5FqyYdGa+VuDp5EJrkLbPq5xhhSAAkMgGUeMpOM0=
 github.com/fluxcd/pkg/ssa v0.24.1/go.mod h1:nEOUOwGotBlNZkTkO6GHPlI0U0BmHTavFd1Jk+TzsGw=
 github.com/fluxcd/pkg/tar v0.2.0 h1:HEUHgONQYsJGeZZ4x6h5nQU9Aox1I4T3bOp1faWTqf8=
@@ -557,8 +557,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/main.go
+++ b/main.go
@@ -108,12 +108,12 @@ func main() {
 
 	flag.Parse()
 
+	logger.SetLogger(logger.NewLogger(logOptions))
+
 	if err := featureGates.WithLogger(setupLog).SupportedFeatures(features.FeatureGates()); err != nil {
 		setupLog.Error(err, "unable to load feature gates")
 		os.Exit(1)
 	}
-
-	ctrl.SetLogger(logger.NewLogger(logOptions))
 
 	watchNamespace := ""
 	if !watchAllNamespaces {


### PR DESCRIPTION
This uses the newly introduced helper from runtime, which also configures the logger for `klog`.

Resulting in all logs now being properly formatted, even when logged by internal Kubernetes elements like the leader election or a dynamic client.

The update from `fluxcd/pkg/runtime` from `v0.29.0` to `v0.31.0` in addition includes a change which configures the event recoder to only log on level `trace` (as opposed to `debug`).