### PR TITLE
Allow decryption secrets in other namespaces

### DIFF
--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -169,7 +169,7 @@ type Decryption struct {
 
 	// The secret name containing the private OpenPGP keys used for decryption.
 	// +optional
-	SecretRef *meta.LocalObjectReference `json:"secretRef,omitempty"`
+	SecretRef *meta.NamespacedObjectReference `json:"secretRef,omitempty"`
 }
 
 // PostBuild describes which actions to perform on the YAML manifest

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -49,7 +49,7 @@ func (in *Decryption) DeepCopyInto(out *Decryption) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(meta.LocalObjectReference)
+		*out = new(meta.NamespacedObjectReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -607,6 +607,10 @@ spec:
                       name:
                         description: Name of the referent.
                         type: string
+                      namespace:
+                        description: Namespace of the referent, when not specified
+                          it acts as LocalObjectReference.
+                        type: string
                     required:
                     - name
                     type: object

--- a/controllers/kustomization_decryptor_test.go
+++ b/controllers/kustomization_decryptor_test.go
@@ -137,7 +137,7 @@ func TestKustomizationReconciler_Decryptor(t *testing.T) {
 			},
 			Decryption: &kustomizev1.Decryption{
 				Provider: "sops",
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: sopsSecretKey.Name,
 				},
 			},

--- a/docs/api/kustomize.md
+++ b/docs/api/kustomize.md
@@ -498,8 +498,8 @@ string
 <td>
 <code>secretRef</code><br>
 <em>
-<a href="https://godoc.org/github.com/fluxcd/pkg/apis/meta#LocalObjectReference">
-github.com/fluxcd/pkg/apis/meta.LocalObjectReference
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/meta#NamespacedObjectReference">
+github.com/fluxcd/pkg/apis/meta.NamespacedObjectReference
 </a>
 </em>
 </td>

--- a/internal/decryptor/decryptor.go
+++ b/internal/decryptor/decryptor.go
@@ -202,8 +202,12 @@ func (d *Decryptor) ImportKeys(ctx context.Context) error {
 	provider := d.kustomization.Spec.Decryption.Provider
 	switch provider {
 	case DecryptionProviderSOPS:
+		var secretNamespace = d.kustomization.Spec.Decryption.SecretRef.Namespace
+		if secretNamespace == "" {
+			secretNamespace = d.kustomization.GetNamespace()
+		}
 		secretName := types.NamespacedName{
-			Namespace: d.kustomization.GetNamespace(),
+			Namespace: secretNamespace,
 			Name:      d.kustomization.Spec.Decryption.SecretRef.Name,
 		}
 

--- a/internal/decryptor/decryptor_test.go
+++ b/internal/decryptor/decryptor_test.go
@@ -147,6 +147,28 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			},
 		},
 		{
+			name: "age key in another namespace",
+			decryption: &kustomizev1.Decryption{
+				Provider: provider,
+				SecretRef: &meta.NamespacedObjectReference{
+					Name:      "age-secret",
+					Namespace: "other",
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "age-secret",
+					Namespace: "other",
+				},
+				Data: map[string][]byte{
+					"age" + DecryptionAgeExt: ageKey,
+				},
+			},
+			inspectFunc: func(g *GomegaWithT, decryptor *Decryptor) {
+				g.Expect(decryptor.ageIdentities).To(HaveLen(1))
+			},
+		},
+		{
 			name: "age key import error",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,

--- a/internal/decryptor/decryptor_test.go
+++ b/internal/decryptor/decryptor_test.go
@@ -92,7 +92,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "PGP key",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "pgp-secret",
 				},
 			},
@@ -110,7 +110,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "PGP key import error",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "pgp-secret",
 				},
 			},
@@ -129,7 +129,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "age key",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "age-secret",
 				},
 			},
@@ -150,7 +150,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "age key import error",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "age-secret",
 				},
 			},
@@ -172,7 +172,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "HC Vault token",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "hcvault-secret",
 				},
 			},
@@ -193,7 +193,7 @@ func TestDecryptor_ImportKeys(t *testing.T) {
 			name: "AWS KMS credentials",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "awskms-secret",
 				},
 			},
@@ -216,7 +216,7 @@ aws_session_token: test-token`),
 			name: "GCP Service Account key",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "gcpkms-secret",
 				},
 			},
@@ -239,7 +239,7 @@ aws_session_token: test-token`),
 			name: "Azure Key Vault token",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "azkv-secret",
 				},
 			},
@@ -262,7 +262,7 @@ clientSecret: some-client-secret`),
 			name: "Azure Key Vault token load config error",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "azkv-secret",
 				},
 			},
@@ -284,7 +284,7 @@ clientSecret: some-client-secret`),
 			name: "Azure Key Vault unsupported config",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "azkv-secret",
 				},
 			},
@@ -306,7 +306,7 @@ clientSecret: some-client-secret`),
 			name: "multiple Secret data entries",
 			decryption: &kustomizev1.Decryption{
 				Provider: provider,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "multiple-secret",
 				},
 			},
@@ -341,7 +341,7 @@ clientSecret: some-client-secret`),
 			name: "non-existing Decryption Secret",
 			decryption: &kustomizev1.Decryption{
 				Provider: DecryptionProviderSOPS,
-				SecretRef: &meta.LocalObjectReference{
+				SecretRef: &meta.NamespacedObjectReference{
 					Name: "does-not-exist",
 				},
 			},


### PR DESCRIPTION
This patch changes the API for `Kustomize` slightly in that it allows decryption secrets to be referenced from another namespace.
I have tested this for backwards-compatibility and found no issues.