### PR TITLE
Support Workload Identity for Azure Vault

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	cloud.google.com/go/kms v1.10.0
 	filippo.io/age v1.1.1
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0-beta.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.4
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.9.0
 	github.com/aws/aws-sdk-go v1.44.231
 	github.com/aws/aws-sdk-go-v2 v1.17.7

--- a/go.sum
+++ b/go.sum
@@ -47,10 +47,10 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
 github.com/Azure/azure-sdk-for-go v63.3.0+incompatible h1:INepVujzUrmArRZjDLHbtER+FkvCoEwyRCXGqOlmDII=
 github.com/Azure/azure-sdk-for-go v63.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0 h1:rTnT/Jrcm+figWlYz4Ixzt0SJVR2cMC8lvZcimipiEY=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0/go.mod h1:ON4tFdPTwRcgWEaVDrN3584Ef+b7GgSJaXxe5fW9t4M=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2 h1:uqM+VoHjVH6zdlkLF2b6O0ZANcHoj3rO0PoQ3jglUJA=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2/go.mod h1:twTKAa1E6hLmSDjLhaCkbTMQKc7p/rNLU40rLxGEOCI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0-beta.1 h1:yLM4ZIC+NRvzwFGpXjUbf5FhPBVxJgmYXkjePgNAx64=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0-beta.1/go.mod h1:ON4tFdPTwRcgWEaVDrN3584Ef+b7GgSJaXxe5fW9t4M=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.4 h1:jpSh2461XzXBEw1MJwvVRJwZS0CAgqS0h6jBdoIFtLk=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.4/go.mod h1:oWa/ZXP08smIi12UyWVbVikBxoZHZCyxijZamTK1i8Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0 h1:leh5DwKv6Ihwi+h60uHtn6UWAxBbZ0q8DwQVMzf61zw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.9.0 h1:TOFrNxfjslms5nLLIMjW7N0+zSALX4KiGsptmpb16AA=

--- a/internal/sops/azkv/config.go
+++ b/internal/sops/azkv/config.go
@@ -8,7 +8,6 @@ package azkv
 
 import (
 	"fmt"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"

--- a/internal/sops/keyservice/server_test.go
+++ b/internal/sops/keyservice/server_test.go
@@ -181,36 +181,6 @@ func TestServer_EncryptDecrypt_azkv(t *testing.T) {
 
 }
 
-func TestServer_EncryptDecrypt_azkv_Fallback(t *testing.T) {
-	g := NewWithT(t)
-
-	fallback := NewMockKeyServer()
-	s := NewServer(WithDefaultServer{Server: fallback})
-
-	key := KeyFromMasterKey(azkv.MasterKeyFromURL("", "", ""))
-	encReq := &keyservice.EncryptRequest{
-		Key:       &key,
-		Plaintext: []byte("some data key"),
-	}
-	_, err := s.Encrypt(context.TODO(), encReq)
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(fallback.encryptReqs).To(HaveLen(1))
-	g.Expect(fallback.encryptReqs).To(ContainElement(encReq))
-	g.Expect(fallback.decryptReqs).To(HaveLen(0))
-
-	fallback = NewMockKeyServer()
-	s = NewServer(WithDefaultServer{Server: fallback})
-
-	decReq := &keyservice.DecryptRequest{
-		Key:        &key,
-		Ciphertext: []byte("some ciphertext"),
-	}
-	_, err = s.Decrypt(context.TODO(), decReq)
-	g.Expect(fallback.decryptReqs).To(HaveLen(1))
-	g.Expect(fallback.decryptReqs).To(ContainElement(decReq))
-	g.Expect(fallback.encryptReqs).To(HaveLen(0))
-}
-
 func TestServer_EncryptDecrypt_gcpkms(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
This pull request adds support for using Azure Workload Identity when decrypting secrets in `Kustomization`

It updates azidentity dependencies to v1.3.0-beta.4 and uses defaultCredentials from environment variables when no secret is set when decrypting with Azure KMS

Closes #795 