### PR TITLE
Fix SOPS azkv envCred

### DIFF
--- a/internal/sops/azkv/keysource.go
+++ b/internal/sops/azkv/keysource.go
@@ -222,14 +222,13 @@ func getDefaultAzureCredential() (azcore.TokenCredential, error) {
 	)
 
 	var errorMessages []string
-	var creds []azcore.TokenCredential
 	options := &azidentity.DefaultAzureCredentialOptions{}
 
 	envCred, err := azidentity.NewEnvironmentCredential(&azidentity.EnvironmentCredentialOptions{
 		ClientOptions: options.ClientOptions, DisableInstanceDiscovery: options.DisableInstanceDiscovery},
 	)
 	if err == nil {
-		creds = append(creds, envCred)
+		return envCred, nil
 	} else {
 		errorMessages = append(errorMessages, "EnvironmentCredential: "+err.Error())
 	}


### PR DESCRIPTION
At the moment, the envCred logic can't actually set the Azure credentials.

This commit fixes the logic so that the environment variables can actually be used to set the Azure credentials.

There are other issues that come up from this block of code, but those can be dealt with separately.