### PR TITLE
docs: Clarify the Kustomize components relative paths requirement 

### DIFF
--- a/docs/spec/v1/kustomization.md
+++ b/docs/spec/v1/kustomization.md
@@ -493,11 +493,11 @@ metadata:
 spec:
   # ...omitted for brevity
   components:
-  - ingress
-  - tls
+  - ../ingress
+  - ../tls
 ```
 
-**Note:** The component paths must be local and relative to the source root.
+**Note:** The components paths must be local and relative to the path specified by `.spec.path`.
 
 **Warning:** Components are an alpha feature in Kustomize and are therefore
 considered experimental in Flux. No guarantees are provided as the feature may


### PR DESCRIPTION
**WARNING**: Since components are alpha level in kustomize this may be removed at any time.

**Add clarification on how to handle component paths**

Currently the advice is that the components are relative to the source root path and after some [investigation](https://github.com/danielloader/fluxcd-kustomization-components/blob/main/clusters/staging/apps.yaml#LL18C24-L18C24) I've found they're relative to the `.spec.path` which itself is an absolute reference to the source root.

Updated the documentation to match.

