### PR TITLE
Use kustomization namespace for empty dependency source namespace

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -483,8 +483,17 @@ func (r *KustomizationReconciler) checkDependencies(ctx context.Context,
 			return fmt.Errorf("dependency '%s' is not ready", dName)
 		}
 
+		srcNamespace := k.Spec.SourceRef.Namespace
+		if srcNamespace == "" {
+			srcNamespace = k.GetNamespace()
+		}
+		dSrcNamespace := obj.Spec.SourceRef.Namespace
+		if dSrcNamespace == "" {
+			dSrcNamespace = obj.GetNamespace()
+		}
+
 		if k.Spec.SourceRef.Name == obj.Spec.SourceRef.Name &&
-			k.Spec.SourceRef.Namespace == obj.Spec.SourceRef.Namespace &&
+			srcNamespace == dSrcNamespace &&
 			k.Spec.SourceRef.Kind == obj.Spec.SourceRef.Kind &&
 			!source.GetArtifact().HasRevision(k.Status.LastAppliedRevision) {
 			return fmt.Errorf("dependency '%s' revision is not up to date", dName)


### PR DESCRIPTION
Kustomize controller uses the namespace of the kustomization resource if the sourceRef is empty. However, this policy doesn't applied to dependencies. This can be problematic if the same named `Sources` without explicit namespace is in different namespace.

This commit fixes this issue by using kustomization's namespace when checking dependencies if the namespace in sourceRef is empty.