### PR TITLE
controller: jitter requeue interval

### DIFF
--- a/api/v1/kustomization_types.go
+++ b/api/v1/kustomization_types.go
@@ -53,6 +53,8 @@ type KustomizationSpec struct {
 	Decryption *Decryption `json:"decryption,omitempty"`
 
 	// The interval at which to reconcile the Kustomization.
+	// This interval is approximate and may be subject to jitter to ensure
+	// efficient use of resources.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -170,6 +170,8 @@ spec:
                 type: array
               interval:
                 description: The interval at which to reconcile the Kustomization.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               kubeConfig:

--- a/docs/api/v1/kustomize.md
+++ b/docs/api/v1/kustomize.md
@@ -125,7 +125,9 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<p>The interval at which to reconcile the Kustomization.</p>
+<p>The interval at which to reconcile the Kustomization.
+This interval is approximate and may be subject to jitter to ensure
+efficient use of resources.</p>
 </td>
 </tr>
 <tr>
@@ -607,7 +609,9 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<p>The interval at which to reconcile the Kustomization.</p>
+<p>The interval at which to reconcile the Kustomization.
+This interval is approximate and may be subject to jitter to ensure
+efficient use of resources.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -186,6 +186,11 @@ If the `.metadata.generation` of a resource changes (due to e.g. a change to
 the spec) or the Source revision changes (which generates a Kubernetes event),
 this is handled instantly outside the interval window.
 
+**Note:** The controller can be configured to apply a jitter to the interval in
+order to distribute the load more evenly when multiple Kustomization objects are
+set up with the same interval. For more information, please refer to the
+[kustomize-controller configuration options](https://fluxcd.io/flux/components/kustomize/options/).
+
 ### Retry interval
 
 `.spec.retryInterval` is an optional field to specify the interval at which to

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	runtimeCtrl "github.com/fluxcd/pkg/runtime/controller"
 	"github.com/fluxcd/pkg/runtime/events"
 	feathelper "github.com/fluxcd/pkg/runtime/features"
+	"github.com/fluxcd/pkg/runtime/jitter"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
 	"github.com/fluxcd/pkg/runtime/logger"
 	"github.com/fluxcd/pkg/runtime/pprof"
@@ -84,6 +85,7 @@ func main() {
 		leaderElectionOptions leaderelection.Options
 		rateLimiterOptions    runtimeCtrl.RateLimiterOptions
 		watchOptions          runtimeCtrl.WatchOptions
+		intervalJitterOptions jitter.IntervalOptions
 		aclOptions            acl.Options
 		noRemoteBases         bool
 		httpRetry             int
@@ -109,6 +111,7 @@ func main() {
 	rateLimiterOptions.BindFlags(flag.CommandLine)
 	featureGates.BindFlags(flag.CommandLine)
 	watchOptions.BindFlags(flag.CommandLine)
+	intervalJitterOptions.BindFlags(flag.CommandLine)
 
 	flag.Parse()
 
@@ -118,6 +121,11 @@ func main() {
 
 	if err := featureGates.WithLogger(setupLog).SupportedFeatures(features.FeatureGates()); err != nil {
 		setupLog.Error(err, "unable to load feature gates")
+		os.Exit(1)
+	}
+
+	if err := intervalJitterOptions.SetGlobalJitter(nil); err != nil {
+		setupLog.Error(err, "unable to set global jitter")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Add a `--interval-jitter-percentage` flag to the controller to add a +/- percentage jitter to the `Kustomization.spec.interval`.

Part of: https://github.com/fluxcd/flux2/issues/4120