### PR TITLE
Delete stale metrics on object delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.1.2
 	github.com/fluxcd/pkg/http/fetch v0.5.2
 	github.com/fluxcd/pkg/kustomize v1.3.4
-	github.com/fluxcd/pkg/runtime v0.41.0
+	github.com/fluxcd/pkg/runtime v0.42.0
 	github.com/fluxcd/pkg/ssa v0.30.0
 	github.com/fluxcd/pkg/tar v0.2.0
 	github.com/fluxcd/pkg/testserver v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/fluxcd/pkg/http/fetch v0.5.2 h1:0yJPGnjBUFiU3be/5a0IwAcSR29RvGwbsCU4z
 github.com/fluxcd/pkg/http/fetch v0.5.2/go.mod h1:GV8ghKmWY54q0qYHe/erJffe5XlkjSReQV4Bog0rj8w=
 github.com/fluxcd/pkg/kustomize v1.3.4 h1:+XA4umfhkFqrNYQp3ZmKSJy4i3LWjbgoi6H4PllkkkA=
 github.com/fluxcd/pkg/kustomize v1.3.4/go.mod h1:nsbsNGe6nQY6DGYYPowFGQlhxFRcaRFvbwqhCbwAQuE=
-github.com/fluxcd/pkg/runtime v0.41.0 h1:hjWUwVRCKDuGEUhovWrygt/6PRry4p278yKuJNgTfv8=
-github.com/fluxcd/pkg/runtime v0.41.0/go.mod h1:1GN+nxoQ7LmSsLJwjH8JW8pA27tBSO+KLH43HpywCDM=
+github.com/fluxcd/pkg/runtime v0.42.0 h1:a5DQ/f90YjoHBmiXZUpnp4bDSLORjInbmqP7K11L4uY=
+github.com/fluxcd/pkg/runtime v0.42.0/go.mod h1:p6A3xWVV8cKLLQW0N90GehKgGMMmbNYv+OSJ/0qB0vg=
 github.com/fluxcd/pkg/sourceignore v0.3.4 h1:0cfS2Pj7xp2qpaerMjYqOBr82LC+/mGHl6v6pRbi5hs=
 github.com/fluxcd/pkg/sourceignore v0.3.4/go.mod h1:ejLx+/uIrPUgqVzMTR5JiWuUnzs+zTkoEf9gS92LqaE=
 github.com/fluxcd/pkg/ssa v0.30.0 h1:SYf8EBXevbTNwdHoKqRuU00YdnmqqUuR5xcciRrIi0E=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	kcheck "github.com/fluxcd/pkg/runtime/conditions/check"
 	"github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/testenv"
 	"github.com/fluxcd/pkg/testserver"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -160,7 +161,7 @@ func runInContext(registerControllers func(*testenv.Environment), run func() int
 func TestMain(m *testing.M) {
 	code := runInContext(func(testEnv *testenv.Environment) {
 		controllerName := "kustomize-controller"
-		testMetricsH = controller.MustMakeMetrics(testEnv)
+		testMetricsH = controller.NewMetrics(testEnv, metrics.MustMakeRecorder(), kustomizev1.KustomizationFinalizer)
 		kstatusCheck = kcheck.NewChecker(testEnv.Client,
 			&kcheck.Conditions{
 				NegativePolarity: []string{meta.StalledCondition, meta.ReconcilingCondition},

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/jitter"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
 	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -197,7 +198,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	metricsH := runtimeCtrl.MustMakeMetrics(mgr)
+	metricsH := runtimeCtrl.NewMetrics(mgr, metrics.MustMakeRecorder(), kustomizev1.KustomizationFinalizer)
 
 	jobStatusReader := statusreaders.NewCustomJobStatusReader(mgr.GetRESTMapper())
 	pollingOpts := polling.Options{


### PR DESCRIPTION
~Depends on https://github.com/fluxcd/pkg/pull/612~

The metrics helper now accepts owned finalizers to determine if an object is no longer managed by the controller and is being deleted, and deletes the metrics associated with the object.

Before this change, the following metrics continued to be exported even after the associated object is deleted:

```
gotk_reconcile_condition{kind="Kustomization",name="podinfo",namespace="default",status="False",type="Ready"} 0
gotk_reconcile_condition{kind="Kustomization",name="podinfo",namespace="default",status="True",type="Ready"} 1
gotk_reconcile_condition{kind="Kustomization",name="podinfo",namespace="default",status="Unknown",type="Ready"} 0
...
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="0.01"} 1
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="0.038363583488692544"} 1
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="0.1471764538093883"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="0.5646216173286169"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="2.166090855590701"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="8.309900738254731"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="31.879757075478317"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="122.30217221643493"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="469.19495946736544"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="1799.9999999999986"} 2
gotk_reconcile_duration_seconds_bucket{kind="Kustomization",name="podinfo",namespace="default",le="+Inf"} 2
gotk_reconcile_duration_seconds_sum{kind="Kustomization",name="podinfo",namespace="default"} 0.092792429
gotk_reconcile_duration_seconds_count{kind="Kustomization",name="podinfo",namespace="default"} 2
...
gotk_suspend_status{kind="Kustomization",name="podinfo",namespace="default"} 0
```

With this change, they get deleted once the associated object is deleted.

Also, the metrics helper no longer exports `ConditionDelete` for readiness metrics.