### PR TITLE
Add optional built-in substitution of last attempted revision (1.1.x)

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -95,6 +95,7 @@ type KustomizationReconciler struct {
 	DefaultServiceAccount string
 	KubeConfigOpts        runtimeClient.KubeConfigOptions
 	ConcurrentSSA         int
+	ImplicitSubstitutions bool
 }
 
 // KustomizationReconcilerOptions contains options for the KustomizationReconciler.
@@ -615,6 +616,17 @@ func (r *KustomizationReconciler) build(ctx context.Context,
 					return nil, err
 				}
 			}
+		}
+
+		// add built-in substitutions
+		if r.ImplicitSubstitutions {
+			if obj.Spec.PostBuild == nil {
+				obj.Spec.PostBuild = &kustomizev1.PostBuild{}
+			}
+			if obj.Spec.PostBuild.Substitute == nil {
+				obj.Spec.PostBuild.Substitute = make(map[string]string)
+			}
+			obj.Spec.PostBuild.Substitute["FLUX_LAST_ATTEMPTED_REVISION"] = obj.Status.LastAttemptedRevision
 		}
 
 		// run variable substitutions

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func init() {
 
 func main() {
 	var (
+		implicitSubstitutions bool
 		metricsAddr           string
 		eventsAddr            string
 		healthAddr            string
@@ -101,6 +102,8 @@ func main() {
 	flag.IntVar(&concurrent, "concurrent", 4, "The number of concurrent kustomize reconciles.")
 	flag.IntVar(&concurrentSSA, "concurrent-ssa", 4, "The number of concurrent server-side apply operations.")
 	flag.DurationVar(&requeueDependency, "requeue-dependency", 30*time.Second, "The interval at which failing dependencies are reevaluated.")
+	flag.BoolVar(&implicitSubstitutions, "implicit-substitutions", false,
+		"Perform substitutions of built-in values such as last-attempted-revision; has side effects of ALWAYS performing substitutions!")
 	flag.BoolVar(&noRemoteBases, "no-remote-bases", false,
 		"Disallow remote bases usage in Kustomize overlays. When this flag is enabled, all resources must refer to local files included in the source artifact.")
 	flag.IntVar(&httpRetry, "http-retry", 9, "The maximum number of retries when failing to fetch artifacts over HTTP.")
@@ -223,6 +226,7 @@ func main() {
 		Metrics:               metricsH,
 		EventRecorder:         eventRecorder,
 		NoCrossNamespaceRefs:  aclOptions.NoCrossNamespaceRefs,
+		ImplicitSubstitutions: implicitSubstitutions,
 		NoRemoteBases:         noRemoteBases,
 		FailFast:              failFast,
 		ConcurrentSSA:         concurrentSSA,


### PR DESCRIPTION
The purpose of this new feature (which is CLI-conditional, and defaults to false in order to preserve compatibility) is to allow to refer to the revision that is currently being applied in the resource manifests, via the standard substitutions mechanism.

This PR is for the `release/v1.1.x` branch; a corresponding PR for the `main` branch exists in #971 