### PR TITLE
fix: Consistent artifact fetching retry timing

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -244,10 +244,10 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Requeue the reconciliation if the source artifact is not found.
 	if artifactSource.GetArtifact() == nil {
-		msg := "Source is not ready, artifact not found"
+		msg := fmt.Sprintf("Source artifact not found, retrying in %s", r.requeueDependency.String())
 		conditions.MarkFalse(obj, meta.ReadyCondition, kustomizev1.ArtifactFailedReason, msg)
 		log.Info(msg)
-		return ctrl.Result{RequeueAfter: obj.GetRetryInterval()}, nil
+		return ctrl.Result{RequeueAfter: r.requeueDependency}, nil
 	}
 
 	// Check dependencies and requeue the reconciliation if the check fails.


### PR DESCRIPTION
Artifact not found errors (HTTP 404) are requeue using the dependency interval, while for a `nil` Artifact, the interval used for retry was set to the apply retry one. This PR fixes this inconsistency in retry behaviour.