### PR TITLE
fix: Retry when artifacts are available in storage

### DIFF
--- a/internal/controller/kustomization_indexers.go
+++ b/internal/controller/kustomization_indexers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fluxcd/pkg/runtime/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -56,9 +57,9 @@ func (r *KustomizationReconciler) requestsForRevisionChangeOf(indexKey string) h
 		}
 		var dd []dependency.Dependent
 		for _, d := range list.Items {
-			// If the revision of the artifact equals to the last attempted revision,
-			// we should not make a request for this Kustomization
-			if repo.GetArtifact().HasRevision(d.Status.LastAttemptedRevision) {
+			// If the Kustomization is ready and the revision of the artifact equals
+			// to the last attempted revision, we should not make a request for this Kustomization
+			if conditions.IsReady(&d) && repo.GetArtifact().HasRevision(d.Status.LastAttemptedRevision) {
 				continue
 			}
 			dd = append(dd, d.DeepCopy())


### PR DESCRIPTION
After a Flux upgrade, when SC storage is wiped, SC will remove the `.status.artifact` from sources before it tries to fetch from upstream. Due to this change in SC behaviour, the retry logic of the artifact fetcher in KC no longer works as there is no `.status.artifact.url` to retry for. This PR allows for faster recovery, once the artifact is available in storage, even if the revision is the same, KC will reconcile on the spot instead of waiting for the dependency retry interval. 