### PR TITLE
Disable status poller cache by default

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -46,8 +46,8 @@ var features = map[string]bool{
 	// opt-in from v0.33
 	CacheSecretsAndConfigMaps: false,
 	// DisableStatusPollerCache
-	// opt-in from v0.35
-	DisableStatusPollerCache: false,
+	// opt-out from v1.2
+	DisableStatusPollerCache: true,
 	// DisableFailFastBehavior
 	// opt-in from v1.1
 	DisableFailFastBehavior: false,


### PR DESCRIPTION
As observed in the benchmarks performed with https://github.com/stefanprodan/flux-benchmark, the status poller cache fills all the available memory when reconciliation hundreds of resources in-parallel in a single namespace. Disabling the cache by default makes the controller perform better at scale, but users can reenable the cache with `--feature-gates=DisableStatusPollerCache=false`.

Part of: https://github.com/fluxcd/flux2/issues/4410
