### PR TITLE
Log HTTP errors to provide faster feedback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/fluxcd/pkg/apis/event v0.6.0
 	github.com/fluxcd/pkg/apis/kustomize v1.2.0
 	github.com/fluxcd/pkg/apis/meta v1.2.0
-	github.com/fluxcd/pkg/http/fetch v0.7.0
+	github.com/fluxcd/pkg/http/fetch v0.8.0
 	github.com/fluxcd/pkg/kustomize v1.5.0
 	github.com/fluxcd/pkg/runtime v0.43.2
 	github.com/fluxcd/pkg/ssa v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/fluxcd/pkg/apis/kustomize v1.2.0 h1:vkVs+OumxaWso0jNCqdgFFfMHdh+qtZhy
 github.com/fluxcd/pkg/apis/kustomize v1.2.0/go.mod h1:VF7tR/WuVFeum+HaMTHwp+eCtsHiiQlY6ihgqtAnW/M=
 github.com/fluxcd/pkg/apis/meta v1.2.0 h1:O766PzGAdMdQKybSflGL8oV0+GgCNIkdsxfalRyzeO8=
 github.com/fluxcd/pkg/apis/meta v1.2.0/go.mod h1:fU/Az9AoVyIxC0oI4ihG0NVMNnvrcCzdEym3wxjIQsc=
-github.com/fluxcd/pkg/http/fetch v0.7.0 h1:mfp3+UE8gsELRtcv5jYAu/LjOqHXWvm/HbgxdcGlcW4=
-github.com/fluxcd/pkg/http/fetch v0.7.0/go.mod h1:Us49hjAQ1br8iTPNufAgQgtReAaQZbBzNpbRY/8ryWI=
+github.com/fluxcd/pkg/http/fetch v0.8.0 h1:GWiX93y6JaoS0Bm2qy0fo2OeY3xTXP8dME/Ce1iEt8A=
+github.com/fluxcd/pkg/http/fetch v0.8.0/go.mod h1:Rj2b8OVDgbPzeLxt+goa9+qDJDAwC7+jNdgyXsaBglQ=
 github.com/fluxcd/pkg/kustomize v1.5.0 h1:Q2kynQzF4coKlOJq/XaLM+gVmVloaInkoa+vsor6Hho=
 github.com/fluxcd/pkg/kustomize v1.5.0/go.mod h1:QgFwpteTedb7oio5+yN+h+rhSgm253OIjmtoTow+a5c=
 github.com/fluxcd/pkg/runtime v0.43.2 h1:xH2BvttUqJ7wS0zjuBETr2pLXG62QY6f0mdxg5UQKio=


### PR DESCRIPTION
This configures a logger on the archive fetcher, to make HTTP errors surface faster when it fails to retrieve the artifact of a source.

Part of: https://github.com/fluxcd/flux2/issues/4472