### PR TITLE
chore: set explicitly user id and group id

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -30,11 +30,12 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
           capabilities:
             drop: [ "ALL" ]
           seccompProfile:
             type: RuntimeDefault
-
         ports:
           - containerPort: 8080
             name: http-prom


### PR DESCRIPTION
# Motivation

1. Kubernetes [documentation says](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) on `runAsGroup`:

>  If this field is omitted, the primary group ID of the containers will be root(0).

2. Security scanner, Kubescape,  recommends with [C-0013](https://hub.armosec.io/docs/c-0013) to set those values explicitly. 

If this PR is accepted, I can open similar PR on the other components.