### PR TITLE
Fix requeue warning introduced by controller-runtime

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -237,7 +237,7 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		// Retry with backoff on transient errors.
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	// Requeue the reconciliation if the source artifact is not found.


### PR DESCRIPTION
`controller-runtime` prints this `info`-level warning when a non-nil error is returned alongside a non-zero `ctrl.Result`:

```go
if !result.IsZero() {
	log.Info("Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler")
}
```

This PR fixes the warning preserving the current behavior (returning the error, which is logged by `controller-runtime`).