### PR TITLE
Add `StrictPostBuildSubstitutions` feature flag

### DIFF
--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -564,8 +564,7 @@ kind: Kustomization
 metadata:
   name: apps
 spec:
-  interval: 5m
-  path: "./apps/"
+  # ...omitted for brevity
   postBuild:
     substitute:
       cluster_env: "prod"
@@ -629,6 +628,7 @@ kind: Kustomization
 metadata:
   name: apps
 spec:
+  # ...omitted for brevity
   postBuild:
     substitute:
       var_substitution_enabled: "true"
@@ -640,13 +640,11 @@ enclosed in double quotes vars to be treated as strings, for more information se
 
 You can replicate the controller post-build substitutions locally using
 [kustomize](https://github.com/kubernetes-sigs/kustomize)
-and Drone's [envsubst](https://github.com/drone/envsubst):
+and the Flux CLI:
 
 ```console
-$ go install github.com/drone/envsubst/cmd/envsubst
-
 $ export cluster_region=eu-central-1
-$ kustomize build ./apps/ | $GOPATH/bin/envsubst
+$ kustomize build ./apps/ | flux envsubst --strict
 ---
 apiVersion: v1
 kind: Namespace

--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -605,6 +605,11 @@ will print out `${var}`.
 All the undefined variables in the format `${var}` will be substituted with an
 empty string unless a default value is provided e.g. `${var:=default}`.
 
+**Note:** It is recommended to set the `--feature-gates=StrictPostBuildSubstitutions=true`
+controller flag, so that the post-build substitutions will fail if a
+variable without a default value is declared in files but is
+missing from the input vars.
+
 You can disable the variable substitution for certain resources by either
 labelling or annotating them with:
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v1.4.0
 	github.com/fluxcd/pkg/apis/meta v1.4.0
 	github.com/fluxcd/pkg/http/fetch v0.10.0
-	github.com/fluxcd/pkg/kustomize v1.8.0
+	github.com/fluxcd/pkg/kustomize v1.9.0
 	github.com/fluxcd/pkg/runtime v0.46.0
 	github.com/fluxcd/pkg/ssa v0.38.0
 	github.com/fluxcd/pkg/tar v0.6.0
@@ -96,12 +96,12 @@ require (
 	github.com/docker/docker v24.0.9+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/color v1.16.0 // indirect
+	github.com/fluxcd/pkg/envsubst v1.0.0 // indirect
 	github.com/fluxcd/pkg/sourceignore v0.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/getsops/gopgagent v0.0.0-20170926210634-4d7ea76ff71a // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
-github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -143,10 +141,12 @@ github.com/fluxcd/pkg/apis/kustomize v1.4.0 h1:SXoGN9M31fW5tO+wpKMnyHXbjxGUqDo7Y
 github.com/fluxcd/pkg/apis/kustomize v1.4.0/go.mod h1:bZklVWB11tELMss89qYzgg4ClzhFzp0Hm4/8EiHgKew=
 github.com/fluxcd/pkg/apis/meta v1.4.0 h1:nNdgB6FFHP3cubxZCViaCFDUVlAbpq9+hvKEIveOGMg=
 github.com/fluxcd/pkg/apis/meta v1.4.0/go.mod h1:81sZ01ShTuLc1C3M1dFJNkINareBysvmrO1b8zJFFKs=
+github.com/fluxcd/pkg/envsubst v1.0.0 h1:LD86BRNSCGJrvyrH2aX5/pit7RfbFpkzRXogwcazLVk=
+github.com/fluxcd/pkg/envsubst v1.0.0/go.mod h1:VAcb4OxcRdsDix1TRtr/mtTqFGHmNQaOvXQO2REArFQ=
 github.com/fluxcd/pkg/http/fetch v0.10.0 h1:Uh1ZrPa4B4EDgi+NFrY7qP6g9vg1O6JHKg3+iJLtt1w=
 github.com/fluxcd/pkg/http/fetch v0.10.0/go.mod h1:zZOsAqn7iODap40PVq29mcCPEKjDodYvamEaoN6tV/Q=
-github.com/fluxcd/pkg/kustomize v1.8.0 h1:Vf1UwnoP3yScaLi/QrDjgN2d2nI6LcmX4tNRoH+sypY=
-github.com/fluxcd/pkg/kustomize v1.8.0/go.mod h1:yszv9tkYrnC01mcGPct8+bdxpTyxf69k1kmSvk7w0zs=
+github.com/fluxcd/pkg/kustomize v1.9.0 h1:bqS3mXiK1q5TpUtIO5I5b+v/0r96NGJBiearKGUhicA=
+github.com/fluxcd/pkg/kustomize v1.9.0/go.mod h1:PBerk0KzZN/IXaGociVp4MSMvsUQB0jR1P2SqSdixz0=
 github.com/fluxcd/pkg/runtime v0.46.0 h1:+pxFwTk8j8lZIS9Vyc8EJbgvmFp9JqeT6pfLo/0iP98=
 github.com/fluxcd/pkg/runtime v0.46.0/go.mod h1:d9BaIjqoHL71fYeZsssrt08UFONGN2WQRaJ/Ay2d1Cc=
 github.com/fluxcd/pkg/sourceignore v0.6.0 h1:kD6QXL/upPEX66UpR669yK1Bxr/GtjzmZiqBeYpunUQ=

--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -98,6 +98,7 @@ type KustomizationReconciler struct {
 	KubeConfigOpts          runtimeClient.KubeConfigOptions
 	ConcurrentSSA           int
 	DisallowedFieldManagers []string
+	StrictSubstitutions     bool
 }
 
 // KustomizationReconcilerOptions contains options for the KustomizationReconciler.
@@ -622,9 +623,10 @@ func (r *KustomizationReconciler) build(ctx context.Context,
 
 		// run variable substitutions
 		if obj.Spec.PostBuild != nil {
-			outRes, err := generator.SubstituteVariables(ctx, r.Client, u, res, false)
+			outRes, err := generator.SubstituteVariables(ctx, r.Client, u, res,
+				generator.SubstituteWithStrict(r.StrictSubstitutions))
 			if err != nil {
-				return nil, fmt.Errorf("var substitution failed for '%s': %w", res.GetName(), err)
+				return nil, fmt.Errorf("post build failed for '%s': %w", res.GetName(), err)
 			}
 
 			if outRes != nil {

--- a/internal/controller/kustomization_varsub_test.go
+++ b/internal/controller/kustomization_varsub_test.go
@@ -392,6 +392,8 @@ metadata:
 data:
   id: ${q}${number}${q}
   text: |
+    This variable is escaped $${var}
+
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at
     nisl sem. Nullam nec dui ipsum. Nam vehicula volutpat ipsum, ac fringilla
     nisl convallis sed. Aliquam porttitor turpis finibus, finibus velit ut,
@@ -471,6 +473,8 @@ data:
 	resultCM := &corev1.ConfigMap{}
 	g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: id, Namespace: id}, resultCM)).Should(Succeed())
 	g.Expect(resultCM.Data["id"]).To(Equal("123"))
+	g.Expect(resultCM.Data["text"]).To(ContainSubstring(`${var}`))
+	g.Expect(resultCM.Data["text"]).ToNot(ContainSubstring(`$${var}`))
 	g.Expect(resultCM.Data["text"]).To(ContainSubstring(`\?`))
 }
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -39,6 +39,11 @@ const (
 	// DisableFailFastBehavior controls whether the fail-fast behavior when
 	// waiting for resources to become ready should be disabled.
 	DisableFailFastBehavior = "DisableFailFastBehavior"
+
+	// StrictPostBuildSubstitutions controls whether the post-build substitutions
+	// should fail if a variable without a default value is declared in files
+	// but is missing from the input vars.
+	StrictPostBuildSubstitutions = "StrictPostBuildSubstitutions"
 )
 
 var features = map[string]bool{
@@ -51,6 +56,9 @@ var features = map[string]bool{
 	// DisableFailFastBehavior
 	// opt-in from v1.1
 	DisableFailFastBehavior: false,
+	// StrictPostBuildSubstitutions
+	// opt-in from v1.3
+	StrictPostBuildSubstitutions: false,
 }
 
 // FeatureGates contains a list of all supported feature gates and

--- a/main.go
+++ b/main.go
@@ -228,6 +228,12 @@ func main() {
 		failFast = false
 	}
 
+	strictSubstitutions, err := features.Enabled(features.StrictPostBuildSubstitutions)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.StrictPostBuildSubstitutions)
+		os.Exit(1)
+	}
+
 	if err = (&controller.KustomizationReconciler{
 		ControllerName:          controllerName,
 		DefaultServiceAccount:   defaultServiceAccount,
@@ -242,6 +248,7 @@ func main() {
 		PollingOpts:             pollingOpts,
 		StatusPoller:            polling.NewStatusPoller(mgr.GetClient(), mgr.GetRESTMapper(), pollingOpts),
 		DisallowedFieldManagers: disallowedFieldManagers,
+		StrictSubstitutions:     strictSubstitutions,
 	}).SetupWithManager(ctx, mgr, controller.KustomizationReconcilerOptions{
 		DependencyRequeueInterval: requeueDependency,
 		HTTPRetry:                 httpRetry,


### PR DESCRIPTION
Changes:
- Replace `github.com/drone/envsubst` with `github.com/fluxcd/pkg/envsubst`. (fix #1107)
- Add `StrictPostBuildSubstitutions` feature flag, when enabled  the post-build substitutions will fail if a variable without a default value is declared in files but is missing from the input vars. (fix: https://github.com/fluxcd/flux2/issues/4694)