### PR TITLE
Implement name prefix/suffix transformers

### DIFF
--- a/api/v1/kustomization_types.go
+++ b/api/v1/kustomization_types.go
@@ -99,6 +99,20 @@ type KustomizationSpec struct {
 	// +optional
 	HealthChecks []meta.NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
+	// NamePrefix will prefix the names of all managed resources.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=200
+	// +kubebuilder:validation:Optional
+	// +optional
+	NamePrefix string `json:"namePrefix,omitempty" yaml:"namePrefix,omitempty"`
+
+	// NameSuffix will suffix the names of all managed resources.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=200
+	// +kubebuilder:validation:Optional
+	// +optional
+	NameSuffix string `json:"nameSuffix,omitempty" yaml:"nameSuffix,omitempty"`
+
 	// Strategic merge and JSON patches, defined as inline YAML objects,
 	// capable of targeting objects based on kind, label and annotation selectors.
 	// +optional

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -221,6 +221,16 @@ spec:
                 required:
                 - secretRef
                 type: object
+              namePrefix:
+                description: NamePrefix will prefix the names of all managed resources.
+                maxLength: 200
+                minLength: 1
+                type: string
+              nameSuffix:
+                description: NameSuffix will suffix the names of all managed resources.
+                maxLength: 200
+                minLength: 1
+                type: string
               patches:
                 description: |-
                   Strategic merge and JSON patches, defined as inline YAML objects,

--- a/docs/api/v1/kustomize.md
+++ b/docs/api/v1/kustomize.md
@@ -222,6 +222,30 @@ bool
 </tr>
 <tr>
 <td>
+<code>namePrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix will prefix the names of all managed resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nameSuffix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NameSuffix will suffix the names of all managed resources.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>patches</code><br>
 <em>
 <a href="https://godoc.org/github.com/fluxcd/pkg/apis/kustomize#Patch">
@@ -702,6 +726,30 @@ bool
 <td>
 <em>(Optional)</em>
 <p>A list of resources to be included in the health assessment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namePrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix will prefix the names of all managed resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nameSuffix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NameSuffix will suffix the names of all managed resources.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -401,6 +401,22 @@ should be applied to all the Kustomization's resources. It has two optional fiel
   on an object. Any existing annotation will be overridden if it matches with a key
   in this map.
 
+### Name Prefix and Suffix
+
+`.spec.namePrefix` and `.spec.nameSuffix` are optional fields used to specify a prefix and suffix
+to be added to the names of all the resources in the Kustomization.
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app
+spec:
+  # ...omitted for brevity
+  namePrefix: "prefix-"
+  nameSuffix: "-suffix"
+```
+
 ### Patches
 
 `.spec.patches` is an optional list used to specify [Kustomize `patches`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fluxcd/pkg/apis/kustomize v1.4.0
 	github.com/fluxcd/pkg/apis/meta v1.4.0
 	github.com/fluxcd/pkg/http/fetch v0.10.0
-	github.com/fluxcd/pkg/kustomize v1.9.0
+	github.com/fluxcd/pkg/kustomize v1.10.0
 	github.com/fluxcd/pkg/runtime v0.46.0
 	github.com/fluxcd/pkg/ssa v0.38.0
 	github.com/fluxcd/pkg/tar v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/fluxcd/pkg/envsubst v1.0.0 h1:LD86BRNSCGJrvyrH2aX5/pit7RfbFpkzRXogwca
 github.com/fluxcd/pkg/envsubst v1.0.0/go.mod h1:VAcb4OxcRdsDix1TRtr/mtTqFGHmNQaOvXQO2REArFQ=
 github.com/fluxcd/pkg/http/fetch v0.10.0 h1:Uh1ZrPa4B4EDgi+NFrY7qP6g9vg1O6JHKg3+iJLtt1w=
 github.com/fluxcd/pkg/http/fetch v0.10.0/go.mod h1:zZOsAqn7iODap40PVq29mcCPEKjDodYvamEaoN6tV/Q=
-github.com/fluxcd/pkg/kustomize v1.9.0 h1:bqS3mXiK1q5TpUtIO5I5b+v/0r96NGJBiearKGUhicA=
-github.com/fluxcd/pkg/kustomize v1.9.0/go.mod h1:PBerk0KzZN/IXaGociVp4MSMvsUQB0jR1P2SqSdixz0=
+github.com/fluxcd/pkg/kustomize v1.10.0 h1:5upGCY1wgC26chNBqKiaQjtDUm2qJQTDVFLvKNPQb4I=
+github.com/fluxcd/pkg/kustomize v1.10.0/go.mod h1:PBerk0KzZN/IXaGociVp4MSMvsUQB0jR1P2SqSdixz0=
 github.com/fluxcd/pkg/runtime v0.46.0 h1:+pxFwTk8j8lZIS9Vyc8EJbgvmFp9JqeT6pfLo/0iP98=
 github.com/fluxcd/pkg/runtime v0.46.0/go.mod h1:d9BaIjqoHL71fYeZsssrt08UFONGN2WQRaJ/Ay2d1Cc=
 github.com/fluxcd/pkg/sourceignore v0.6.0 h1:kD6QXL/upPEX66UpR669yK1Bxr/GtjzmZiqBeYpunUQ=


### PR DESCRIPTION
Closes: #1133 

`.spec.namePrefix` and `.spec.nameSuffix` are optional fields used to specify a prefix and suffix
to be added to the names of all the resources in the Kustomization.

```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1
kind: Kustomization
metadata:
  name: app
spec:
  # ...omitted for brevity
  namePrefix: "prefix-"
  nameSuffix: "-suffix"
```