### PR TITLE
Add namePrefix/nameSuffix properties to Kustomization

### DIFF
--- a/api/v1/kustomization_types.go
+++ b/api/v1/kustomization_types.go
@@ -99,6 +99,22 @@ type KustomizationSpec struct {
 	// +optional
 	HealthChecks []meta.NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
+	// NamePrefix sets or overrides the namePrefix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NamePrefix string `json:"namePrefix,omitempty"`
+
+	// NameSuffix sets or overrides the nameSuffix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NameSuffix string `json:"nameSuffix,omitempty"`
+
 	// Strategic merge and JSON patches, defined as inline YAML objects,
 	// capable of targeting objects based on kind, label and annotation selectors.
 	// +optional

--- a/api/v1beta1/kustomization_types.go
+++ b/api/v1beta1/kustomization_types.go
@@ -80,6 +80,22 @@ type KustomizationSpec struct {
 	// +optional
 	HealthChecks []meta.NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
+	// NamePrefix sets or overrides the namePrefix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NamePrefix string `json:"namePrefix,omitempty"`
+
+	// NameSuffix sets or overrides the nameSuffix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NameSuffix string `json:"nameSuffix,omitempty"`
+
 	// Strategic merge and JSON patches, defined as inline YAML objects,
 	// capable of targeting objects based on kind, label and annotation selectors.
 	// +optional

--- a/api/v1beta2/kustomization_types.go
+++ b/api/v1beta2/kustomization_types.go
@@ -94,6 +94,22 @@ type KustomizationSpec struct {
 	// +optional
 	HealthChecks []meta.NamespacedObjectKindReference `json:"healthChecks,omitempty"`
 
+	// NamePrefix sets or overrides the namePrefix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NamePrefix string `json:"namePrefix,omitempty"`
+
+	// NameSuffix sets or overrides the nameSuffix in the
+	// kustomization.yaml file.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=252
+	// +kubebuilder:validation:Optional
+	// +optional
+	NameSuffix string `json:"nameSuffix,omitempty"`
+
 	// Strategic merge and JSON patches, defined as inline YAML objects,
 	// capable of targeting objects based on kind, label and annotation selectors.
 	// +optional

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -221,6 +221,20 @@ spec:
                 required:
                 - secretRef
                 type: object
+              namePrefix:
+                description: |-
+                  NamePrefix sets or overrides the namePrefix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
+              nameSuffix:
+                description: |-
+                  NameSuffix sets or overrides the nameSuffix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
               patches:
                 description: |-
                   Strategic merge and JSON patches, defined as inline YAML objects,
@@ -704,6 +718,20 @@ spec:
                     - name
                     type: object
                 type: object
+              namePrefix:
+                description: |-
+                  NamePrefix sets or overrides the namePrefix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
+              nameSuffix:
+                description: |-
+                  NameSuffix sets or overrides the nameSuffix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
               patches:
                 description: |-
                   Strategic merge and JSON patches, defined as inline YAML objects,
@@ -1318,6 +1346,20 @@ spec:
                 required:
                 - secretRef
                 type: object
+              namePrefix:
+                description: |-
+                  NamePrefix sets or overrides the namePrefix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
+              nameSuffix:
+                description: |-
+                  NameSuffix sets or overrides the nameSuffix in the
+                  kustomization.yaml file.
+                maxLength: 252
+                minLength: 1
+                type: string
               patches:
                 description: |-
                   Strategic merge and JSON patches, defined as inline YAML objects,

--- a/docs/api/v1/kustomize.md
+++ b/docs/api/v1/kustomize.md
@@ -222,6 +222,32 @@ bool
 </tr>
 <tr>
 <td>
+<code>namePrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix sets or overrides the namePrefix in the
+kustomization.yaml file.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nameSuffix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NameSuffix sets or overrides the nameSuffix in the
+kustomization.yaml file.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>patches</code><br>
 <em>
 <a href="https://godoc.org/github.com/fluxcd/pkg/apis/kustomize#Patch">
@@ -702,6 +728,32 @@ bool
 <td>
 <em>(Optional)</em>
 <p>A list of resources to be included in the health assessment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namePrefix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamePrefix sets or overrides the namePrefix in the
+kustomization.yaml file.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nameSuffix</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NameSuffix sets or overrides the nameSuffix in the
+kustomization.yaml file.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Similarly to targetNamespace property, add namePrefix and nameSuffix properties to allow overridding kustomization.yaml.

Companion of https://github.com/fluxcd/pkg/pull/762