### PR TITLE
Update base image to Alpine 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY internal/ internal/
 ENV CGO_ENABLED=0
 RUN xx-go build -trimpath -a -o kustomize-controller main.go
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
We have found that the current image (fluxcd/kustomize-controller:v1.3.0) has some security vulnerabilities. If you run the trivy image scan, you will see the following result.

```bash
$ trivy image fluxcd/kustomize-controller:v1.3.0

...

fluxcd/kustomize-controller:v1.3.0 (alpine 3.19.1)

Total: 15 (UNKNOWN: 0, LOW: 4, MEDIUM: 8, HIGH: 2, CRITICAL: 1)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2023-42363 │ MEDIUM   │ fixed  │ 1.36.1-r15        │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┼────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ busybox-binsh │ CVE-2023-42363 │          │        │                   │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ git           │ CVE-2024-32002 │ CRITICAL │        │ 2.43.0-r0         │ 2.43.4-r0     │ git: Recursive clones RCE                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-32002                │
│               ├────────────────┼──────────┤        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-32004 │ HIGH     │        │                   │               │ git: RCE while cloning local repos                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-32004                │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-32465 │          │        │                   │               │ git: additional local RCE                                 │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-32465                │
│               ├────────────────┼──────────┤        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-32020 │ LOW      │        │                   │               │ git: insecure hardlinks                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-32020                │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-32021 │          │        │                   │               │ git: symlink bypass                                       │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-32021                │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2024-4603  │ MEDIUM   │        │ 3.1.4-r5          │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2024-4603  │ MEDIUM   │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2023-42363 │ MEDIUM   │        │ 1.36.1-r15        │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘

usr/local/bin/kustomize-controller (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24788 │ HIGH     │ fixed  │ 1.22.2            │ 1.22.3        │ golang: net: malformed DNS message can cause infinite loop │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-24788                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

These security vulnerabilities will be fixed with the update of the Alpine 3.19 to 3.20 base image.