### PR TITLE
docs: Clarify `.spec.decryption.secretRef` usage

### DIFF
--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -739,12 +739,13 @@ Secret, encrypting the `metadata`, `kind` or `apiVersion` fields is not supporte
 An easy way to do this is by appending `--encrypted-regex '^(data|stringData)$'`
 to your `sops --encrypt` command.
 
-It has two required fields:
+It has two fields:
 
+- `.provider`: The secrets decryption provider to be used. This field is required and
+  the only supported value is `sops`.
 - `.secretRef.name`: The name of the secret that contains the keys to be used for
-   decryption.
-- `.provider`: The secrets decryption provider to be used. The only supported
-   value at the moment is `sops`.
+  decryption. This field can be omitted when using the
+  [global decryption](#controller-global-decryption) option.
 
 ```yaml
 ---


### PR DESCRIPTION
Fixes: https://github.com/fluxcd/flux2/discussions/4979