### PR TITLE
Allow cross-shard dependency check

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -89,6 +89,7 @@ type KustomizationReconciler struct {
 	artifactFetchRetries int
 	requeueDependency    time.Duration
 
+	APIReader               client.Reader
 	StatusPoller            *polling.StatusPoller
 	PollingOpts             polling.Options
 	ControllerName          string
@@ -488,7 +489,7 @@ func (r *KustomizationReconciler) checkDependencies(ctx context.Context,
 			Name:      d.Name,
 		}
 		var k kustomizev1.Kustomization
-		err := r.Get(ctx, dName, &k)
+		err := r.APIReader.Get(ctx, dName, &k)
 		if err != nil {
 			return fmt.Errorf("dependency '%s' not found: %w", dName, err)
 		}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -176,6 +176,7 @@ func TestMain(m *testing.M) {
 		reconciler = &KustomizationReconciler{
 			ControllerName:          controllerName,
 			Client:                  testEnv,
+			APIReader:               testEnv,
 			EventRecorder:           testEnv.GetEventRecorderFor(controllerName),
 			Metrics:                 testMetricsH,
 			ConcurrentSSA:           4,

--- a/main.go
+++ b/main.go
@@ -238,6 +238,7 @@ func main() {
 		ControllerName:          controllerName,
 		DefaultServiceAccount:   defaultServiceAccount,
 		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
 		Metrics:                 metricsH,
 		EventRecorder:           eventRecorder,
 		NoCrossNamespaceRefs:    aclOptions.NoCrossNamespaceRefs,


### PR DESCRIPTION
Use the `APIReader` client to bypass the controller runtime cache when checking for dependencies. This allows a Kustomization to depend on other Kustomizations managed by different controller shards.

Fix: #1175