### PR TITLE
Remove deprecated object metrics

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -185,9 +185,7 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 
 		// Record Prometheus metrics.
-		r.Metrics.RecordReadiness(ctx, obj)
 		r.Metrics.RecordDuration(ctx, obj, reconcileStart)
-		r.Metrics.RecordSuspend(ctx, obj, obj.Spec.Suspend)
 
 		// Log and emit success event.
 		if conditions.IsReady(obj) {


### PR DESCRIPTION
Suspend and readiness metrics recording removed from Kustomization reconciler.

Refer https://github.com/fluxcd/flux2/issues/5083.