### PR TITLE
feat: be able to import any k8s obj as source

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -173,8 +174,10 @@ func TestMain(m *testing.M) {
 		// for inspection.
 		kstatusInProgressCheck = kcheck.NewInProgressChecker(testEnv.Client)
 		kstatusInProgressCheck.DisableFetch = true
+
 		reconciler = &KustomizationReconciler{
 			ControllerName:          controllerName,
+			DiscoveryClient:         discovery.NewDiscoveryClientForConfigOrDie(testEnv.Config),
 			Client:                  testEnv,
 			APIReader:               testEnv,
 			EventRecorder:           testEnv.GetEventRecorderFor(controllerName),

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	flag "github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -234,10 +235,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to create discovery client")
+		os.Exit(1)
+	}
+
 	if err = (&controller.KustomizationReconciler{
 		ControllerName:          controllerName,
 		DefaultServiceAccount:   defaultServiceAccount,
 		Client:                  mgr.GetClient(),
+		DiscoveryClient:         discoveryClient,
 		APIReader:               mgr.GetAPIReader(),
 		Metrics:                 metricsH,
 		EventRecorder:           eventRecorder,


### PR DESCRIPTION
This pull request introduces several significant changes to the `kustomization_controller` to enhance the discovery and handling of source references, as well as adding new tests to ensure functionality. The most important changes include adding a `DiscoveryClient` to the `KustomizationReconciler`, refactoring the source retrieval logic, and adding a new test for the `SourceRefAPIVersion`.

### Enhancements to `KustomizationReconciler`:

* Added `DiscoveryClient` to the `KustomizationReconciler` struct for dynamic API discovery. (`internal/controller/kustomization_controller.go`)
* Introduced the `Source` type and refactored the `getSource` method to use `unstructured.Unstructured` for dynamic API version handling. (`internal/controller/kustomization_controller.go`)

### Codebase updates:

* Updated imports to include `discovery` package in multiple files. (`internal/controller/kustomization_controller.go`, `internal/controller/suite_test.go`, `main.go`) [[1]](diffhunk://#diff-762df32b09bbcadc8b8b03badbee007cb1aa0e45788a2881a7eb6b3b929158eeR38-R41) [[2]](diffhunk://#diff-f7d7a9a5a676515f82d0e398a01962d41c18d9d50112e1852a9edb3a31976bd3R34) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R27)
* Modified the `main` function to initialize `DiscoveryClient` and pass it to the `KustomizationReconciler`. (`main.go`)

### Testing improvements:

* Added `TestKustomizationReconciler_SourceRefAPIVersion` to verify the correct handling of `SourceRef` API versions. (`internal/controller/kustomization_controller_test.go`)
* Updated the test suite setup to include `DiscoveryClient`. (`internal/controller/suite_test.go`)