### PR TITLE
Add OCI origin revision to events

### DIFF
--- a/api/v1/kustomization_types.go
+++ b/api/v1/kustomization_types.go
@@ -263,6 +263,14 @@ type KustomizationStatus struct {
 	// +optional
 	LastAppliedRevision string `json:"lastAppliedRevision,omitempty"`
 
+	// The last successfully applied origin revision.
+	// Equals the origin revision of the applied Artifact from the referenced Source.
+	// Usually present on the Metadata of the applied Artifact and depends on the
+	// Source type, e.g. for OCI it's the value associated with the key
+	// "org.opencontainers.image.revision".
+	// +optional
+	LastAppliedOriginRevision string `json:"lastAppliedOriginRevision,omitempty"`
+
 	// LastAttemptedRevision is the revision of the last reconciliation attempt.
 	// +optional
 	LastAttemptedRevision string `json:"lastAttemptedRevision,omitempty"`

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -520,6 +520,14 @@ spec:
                 required:
                 - entries
                 type: object
+              lastAppliedOriginRevision:
+                description: |-
+                  The last successfully applied origin revision.
+                  Equals the origin revision of the applied Artifact from the referenced Source.
+                  Usually present on the Metadata of the applied Artifact and depends on the
+                  Source type, e.g. for OCI it's the value associated with the key
+                  "org.opencontainers.image.revision".
+                type: string
               lastAppliedRevision:
                 description: |-
                   The last successfully applied revision.

--- a/docs/api/v1/kustomize.md
+++ b/docs/api/v1/kustomize.md
@@ -994,6 +994,22 @@ Equals the Revision of the applied Artifact from the referenced Source.</p>
 </tr>
 <tr>
 <td>
+<code>lastAppliedOriginRevision</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The last successfully applied origin revision.
+Equals the origin revision of the applied Artifact from the referenced Source.
+Usually present on the Metadata of the applied Artifact and depends on the
+Source type, e.g. for OCI it&rsquo;s the value associated with the key
+&ldquo;org.opencontainers.image.revision&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>lastAttemptedRevision</code><br>
 <em>
 string

--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -1915,6 +1915,21 @@ Status:
 `.status.lastAppliedRevision` is the last revision of the Artifact from the
 referred Source object that was successfully applied to the cluster.
 
+### Last applied origin revision
+
+`status.lastAppliedOriginRevision` is the last origin revision of the Artifact
+from the referred Source object that was successfully applied to the cluster.
+
+This field is usually retrieved from the Metadata of the Artifact and depends
+on the Source type. For example, for OCI artifacts this is the value associated
+with the standard metadata key `org.opencontainers.image.revision`, which is
+used to track the revision of the source code that was used to build the OCI
+artifact.
+
+The controller will forward this value when emitting events in the metadata
+key `originRevision`. The notification-controller will look for this key in
+the event metadata when sending *commit status update* events to Git providers.
+
 ### Last attempted revision
 
 `.status.lastAttemptedRevision` is the last revision of the Artifact from the

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/fluxcd/cli-utils v0.36.0-flux.11
 	github.com/fluxcd/kustomize-controller/api v1.4.0
 	github.com/fluxcd/pkg/apis/acl v0.5.0
-	github.com/fluxcd/pkg/apis/event v0.13.0
+	github.com/fluxcd/pkg/apis/event v0.15.0
 	github.com/fluxcd/pkg/apis/kustomize v1.8.0
 	github.com/fluxcd/pkg/apis/meta v1.9.0
 	github.com/fluxcd/pkg/http/fetch v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/fluxcd/cli-utils v0.36.0-flux.11 h1:W0y2uvCVkcE8bgV9jgoGSjzWbLFiNq1Aj
 github.com/fluxcd/cli-utils v0.36.0-flux.11/go.mod h1:WZ7xUpZbK+O6HBxA5UWqzWTLSSltdmj4wS1LstS5Dqs=
 github.com/fluxcd/pkg/apis/acl v0.5.0 h1:+ykKezgerKUlZwSYFUy03lPMOIAyWlqvMNNLIWWqOhk=
 github.com/fluxcd/pkg/apis/acl v0.5.0/go.mod h1:IVDZx3MAoDWjlLrJHMF9Z27huFuXAEQlnbWw0M6EcTs=
-github.com/fluxcd/pkg/apis/event v0.13.0 h1:m5qHAhYIC0+mRFy5OC8FZxBVBGJM3qxJ/sEg2Vgx4T8=
-github.com/fluxcd/pkg/apis/event v0.13.0/go.mod h1:aRK2AONnjjSNW61B6Iy3SW4YHozACntnJeGm3fFqDqA=
+github.com/fluxcd/pkg/apis/event v0.15.0 h1:k1suqIfVxnhEeKlGkvlHAbOYXjY8wRixT/OZcIuakqA=
+github.com/fluxcd/pkg/apis/event v0.15.0/go.mod h1:aRK2AONnjjSNW61B6Iy3SW4YHozACntnJeGm3fFqDqA=
 github.com/fluxcd/pkg/apis/kustomize v1.8.0 h1:HH6YRa3SMS72KK4cUyb9m5sK/dZH+Eti1qhjWDCgwKg=
 github.com/fluxcd/pkg/apis/kustomize v1.8.0/go.mod h1:QCKIFj1ocdndaWSkrLs5JKvdGNYyTzQX1ZB3lYTwma0=
 github.com/fluxcd/pkg/apis/meta v1.9.0 h1:wPgm7bWNJZ/ImS5GqikOxt362IgLPFBG73dZ27uWRiQ=

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+const OCIArtifactOriginRevisionAnnotation = "org.opencontainers.image.revision"

--- a/internal/controller/kustomization_origin_revision_test.go
+++ b/internal/controller/kustomization_origin_revision_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	"github.com/fluxcd/pkg/apis/meta"
+	"github.com/fluxcd/pkg/testserver"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	. "github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+)
+
+func TestKustomizationReconciler_OriginRevision(t *testing.T) {
+	g := NewWithT(t)
+	id := "force-" + randStringRunes(5)
+	revision := "v1.0.0"
+
+	err := createNamespace(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+	err = createKubeConfigSecret(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create kubeconfig secret")
+
+	manifests := func(name string, data string) []testserver.File {
+		return []testserver.File{
+			{
+				Name: "secret.yaml",
+				Body: fmt.Sprintf(`---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %[1]s
+stringData:
+  key: "%[2]s"
+`, name, data),
+			},
+		}
+	}
+
+	artifact, err := testServer.ArtifactFromFiles(manifests(id, randStringRunes(5)))
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create artifact from files")
+
+	repositoryName := types.NamespacedName{
+		Name:      randStringRunes(5),
+		Namespace: id,
+	}
+
+	err = applyGitRepository(repositoryName, artifact, revision,
+		withGitRepoArtifactMetadata(OCIArtifactOriginRevisionAnnotation, "orev"))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	kustomizationKey := types.NamespacedName{
+		Name:      fmt.Sprintf("force-%s", randStringRunes(5)),
+		Namespace: id,
+	}
+	kustomization := &kustomizev1.Kustomization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kustomizationKey.Name,
+			Namespace: kustomizationKey.Namespace,
+		},
+		Spec: kustomizev1.KustomizationSpec{
+			Interval: metav1.Duration{Duration: reconciliationInterval},
+			Path:     "./",
+			KubeConfig: &meta.KubeConfigReference{
+				SecretRef: meta.SecretKeyReference{
+					Name: "kubeconfig",
+				},
+			},
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Name:      repositoryName.Name,
+				Namespace: repositoryName.Namespace,
+				Kind:      sourcev1.GitRepositoryKind,
+			},
+			TargetNamespace: id,
+		},
+	}
+
+	g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
+
+	resultK := &kustomizev1.Kustomization{}
+	readyCondition := &metav1.Condition{}
+
+	g.Eventually(func() bool {
+		_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+		readyCondition = apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+		return resultK.Status.LastAppliedRevision == revision
+	}, timeout, time.Second).Should(BeTrue())
+
+	g.Expect(readyCondition.Reason).To(Equal(meta.ReconciliationSucceededReason))
+
+	g.Expect(resultK.Status.LastAppliedOriginRevision).To(Equal("orev"))
+
+	events := getEvents(kustomizationKey.Name, nil)
+	g.Expect(events).To(Not(BeEmpty()))
+
+	annotationKey := kustomizev1.GroupVersion.Group + "/" + eventv1.MetaOriginRevisionKey
+	for _, e := range events {
+		g.Expect(e.GetAnnotations()).To(HaveKeyWithValue(annotationKey, "orev"))
+	}
+}


### PR DESCRIPTION
Part of: https://github.com/fluxcd/flux2/issues/5148

I have tested this e2e using GitHub:

![oci-bad-commit-status](https://github.com/user-attachments/assets/5c436fec-edb7-4e91-a4ca-e932335026fb)

![oci-good-commit-status](https://github.com/user-attachments/assets/4a397f4d-142d-4598-99cf-120f0aaee801)
