### PR TITLE
Use RESTMapper with preferred version fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.10.0
 	github.com/fluxcd/pkg/http/fetch v0.15.0
 	github.com/fluxcd/pkg/kustomize v1.16.0
-	github.com/fluxcd/pkg/runtime v0.54.0
+	github.com/fluxcd/pkg/runtime v0.55.1-0.20250312082753-798e9612dbb5
 	github.com/fluxcd/pkg/ssa v0.45.1
 	github.com/fluxcd/pkg/tar v0.11.0
 	github.com/fluxcd/pkg/testserver v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/fluxcd/pkg/http/fetch v0.15.0 h1:AJ1JuE2asuK4QMfbHjxctFURke5FvZtyljjI
 github.com/fluxcd/pkg/http/fetch v0.15.0/go.mod h1:feTESfETKU14jq+e/Ce8QnMBTCh9O79bLMSMe5t55fQ=
 github.com/fluxcd/pkg/kustomize v1.16.0 h1:UBOeIvkrC6y4owYs7vZwG5PUVFeqnRoDFN9eaNhuNPI=
 github.com/fluxcd/pkg/kustomize v1.16.0/go.mod h1:6yQkAZaG+w3nXY30LbyWRYHimjRcLRwlYkrwG0ygMSI=
-github.com/fluxcd/pkg/runtime v0.54.0 h1:H7zSW8mTIZIkXaOdxzvi+oK0cH3jccyLoCBbXDPIGjg=
-github.com/fluxcd/pkg/runtime v0.54.0/go.mod h1:PC73Yn/AaBQXnd2YYq0cnQqF3RmQKoM265crrjFJnKI=
+github.com/fluxcd/pkg/runtime v0.55.1-0.20250312082753-798e9612dbb5 h1:/N7Pc+xBvs1XI3vPeAarXiwmGQW40dO82ZaONa+uXwQ=
+github.com/fluxcd/pkg/runtime v0.55.1-0.20250312082753-798e9612dbb5/go.mod h1:jjgP0s4OGoivPhJSKqjZvFDzdtRKBYDoNeErzxWp2ZQ=
 github.com/fluxcd/pkg/sourceignore v0.11.0 h1:xzpYmc5/t/Ck+/DkJSX3r+VbahDRIAn5kbv04fynWUo=
 github.com/fluxcd/pkg/sourceignore v0.11.0/go.mod h1:ri2FvlzX8ep2iszOK5gF/riYq2TNgpVvsfJ2QY0dLWI=
 github.com/fluxcd/pkg/ssa v0.45.1 h1:ISl84TJwRP/GuZXrKiR9Tf8JOnG5XFgtjcYoR4XQYf4=


### PR DESCRIPTION
Test fix from https://github.com/kubernetes-sigs/controller-runtime/pull/3151 included in https://github.com/fluxcd/pkg/pull/883

Test images:
- ghcr.io/fluxcd/kustomize-controller:rc-975a70d7
- docker.io/fluxcd/kustomize-controller:rc-975a70d7