### PR TITLE
Skip emitting events for suspended Kustomizations

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -189,6 +189,11 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// Record Prometheus metrics.
 		r.Metrics.RecordDuration(ctx, obj, reconcileStart)
 
+		// Do not proceed if the Kustomization is suspended
+		if obj.Spec.Suspend {
+			return
+		}
+
 		// Log and emit success event.
 		if conditions.IsReady(obj) {
 			msg := fmt.Sprintf("Reconciliation finished in %s, next run in %s",


### PR DESCRIPTION
There are edge cases where a reconciliation can be triggered on a suspended Kustomization, mainly through changes in a source. In these cases a "no-op" reconciliation occurs, which can be confusing for the user. This PR prevents the controller from updating the status and issuing events.

Fix: https://github.com/fluxcd/flux2/issues/5174