### PR TITLE
Queue immediate reconciliation on kustomization dependency

### DIFF
--- a/internal/controller/dependency_predicate.go
+++ b/internal/controller/dependency_predicate.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/fluxcd/pkg/runtime/conditions"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+)
+
+type KustomizationReadyChangePredicate struct {
+	predicate.Funcs
+}
+
+func (KustomizationReadyChangePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil || e.ObjectOld == nil {
+		return false
+	}
+
+	newKs, ok := e.ObjectNew.(*kustomizev1.Kustomization)
+	if !ok {
+		return false
+	}
+	oldKs, ok := e.ObjectOld.(*kustomizev1.Kustomization)
+	if !ok {
+		return false
+	}
+
+	if !conditions.IsReady(newKs) {
+		return false
+	}
+	if !conditions.IsReady(oldKs) {
+		return true
+	}
+
+	return oldKs.Status.LastAppliedRevision != newKs.Status.LastAppliedRevision
+}

--- a/internal/controller/kustomization_dependson_test.go
+++ b/internal/controller/kustomization_dependson_test.go
@@ -29,6 +29,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -136,6 +137,14 @@ spec:
 		},
 	}
 
+	dependencyKey := types.NamespacedName{
+		Name:      fmt.Sprintf("dep-%s", randStringRunes(5)),
+		Namespace: id,
+	}
+	dependencyKs := kustomization.DeepCopy()
+	dependencyKs.ObjectMeta.Name = dependencyKey.Name
+	dependencyKs.ObjectMeta.Namespace = dependencyKey.Namespace
+
 	g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
 
 	resultK := &kustomizev1.Kustomization{}
@@ -170,8 +179,8 @@ spec:
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
 			resultK.Spec.DependsOn = []kustomizev1.DependencyReference{
 				{
-					Namespace: id,
-					Name:      "root",
+					Namespace: dependencyKey.Namespace,
+					Name:      dependencyKey.Name,
 				},
 			}
 			return k8sClient.Update(context.Background(), resultK)
@@ -180,6 +189,17 @@ spec:
 		g.Eventually(func() bool {
 			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
 			return conditions.HasAnyReason(resultK, meta.ReadyCondition, meta.DependencyNotReadyReason)
+		}, timeout, time.Second).Should(BeTrue())
+	})
+
+	t.Run("reconciles once dependency becomes ready", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(k8sClient.Create(context.Background(), dependencyKs)).To(Succeed())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			ready := apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+			return ready.Reason == meta.ReconciliationSucceededReason
 		}, timeout, time.Second).Should(BeTrue())
 	})
 }

--- a/internal/controller/kustomization_fetcher_test.go
+++ b/internal/controller/kustomization_fetcher_test.go
@@ -143,6 +143,7 @@ stringData:
 	t.Run("recovers after not found errors", func(t *testing.T) {
 		g.Expect(k8sClient.Get(context.Background(), repositoryName, repo)).Should(Succeed())
 		repo.Status.Artifact.URL = repoURL
+		repo.Status.Artifact.Revision = "new-revision"
 		repo.ManagedFields = nil
 		g.Expect(k8sClient.Status().Update(context.Background(), repo)).To(Succeed())
 

--- a/internal/controller/kustomization_indexers.go
+++ b/internal/controller/kustomization_indexers.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -30,6 +32,10 @@ import (
 	"github.com/fluxcd/pkg/runtime/dependency"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+)
+
+const (
+	dependsOnIndexKey string = ".metadata.dependsOn"
 )
 
 func (r *KustomizationReconciler) requestsForRevisionChangeOf(indexKey string) handler.MapFunc {
@@ -72,6 +78,73 @@ func (r *KustomizationReconciler) requestsForRevisionChangeOf(indexKey string) h
 		}
 		return reqs
 	}
+}
+
+func isNotWaitingForDependency(k *kustomizev1.Kustomization) bool {
+	c := conditions.Get(k, meta.ReadyCondition)
+	if c == nil {
+		return true
+	}
+	return c.Status != metav1.ConditionFalse || c.Reason != meta.DependencyNotReadyReason
+}
+
+func (r *KustomizationReconciler) hasNotReadyDependency(ctx context.Context,
+	k *kustomizev1.Kustomization, current client.ObjectKey) bool {
+
+	log := ctrl.LoggerFrom(ctx)
+	var ks kustomizev1.Kustomization
+	for _, d := range k.Spec.DependsOn {
+		namespace := k.GetNamespace()
+		if d.Namespace != "" {
+			namespace = d.Namespace
+		}
+		objectKey := client.ObjectKey{Namespace: namespace, Name: d.Name}
+		if objectKey == current {
+			continue
+		}
+		if err := r.Get(ctx, objectKey, &ks); err != nil {
+			log.Error(err, "failed to get object for dependency change")
+			return true
+		}
+		if !conditions.IsReady(&ks) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *KustomizationReconciler) requestsForDependents(ctx context.Context, obj client.Object) []reconcile.Request {
+	objectKey := client.ObjectKeyFromObject(obj)
+	log := ctrl.LoggerFrom(ctx)
+	debugLog := log.V(1).WithValues("dependency", map[string]string{
+		"name":      objectKey.Name,
+		"namespace": objectKey.Namespace,
+	})
+
+	var list kustomizev1.KustomizationList
+	if err := r.List(ctx, &list, client.MatchingFields{dependsOnIndexKey: objectKey.String()}); err != nil {
+		log.Error(err, "failed to list objects for dependency change")
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for _, d := range list.Items {
+		if isNotWaitingForDependency(&d) {
+			continue
+		}
+		if r.hasNotReadyDependency(ctx, &d, objectKey) {
+			continue
+		}
+		debugLog.Info("requesting reconciliation of dependent", "dependent", map[string]string{
+			"name":      d.Name,
+			"namespace": d.Namespace,
+		})
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      d.Name,
+			Namespace: d.Namespace,
+		}})
+	}
+	return reqs
 }
 
 func (r *KustomizationReconciler) indexBy(kind string) func(o client.Object) []string {
@@ -142,4 +215,23 @@ func sortAndEnqueue(dd []dependency.Dependent) ([]reconcile.Request, error) {
 		reqs[i].NamespacedName.Namespace = sorted[i].Namespace
 	}
 	return reqs, nil
+}
+
+// index kustomizations by their Spec.DependsOn
+func (r *KustomizationReconciler) indexDependsOn(o client.Object) []string {
+	k, ok := o.(*kustomizev1.Kustomization)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Kustomization, got %T", o))
+	}
+
+	deps := make([]string, len(k.Spec.DependsOn))
+	for i, dep := range k.Spec.DependsOn {
+		namespace := k.GetNamespace()
+		if dep.Namespace != "" {
+			namespace = dep.Namespace
+		}
+		deps[i] = fmt.Sprintf("%s/%s", namespace, dep.Name)
+	}
+
+	return deps
 }

--- a/internal/controller/kustomization_manager.go
+++ b/internal/controller/kustomization_manager.go
@@ -44,6 +44,7 @@ type KustomizationReconcilerOptions struct {
 	WatchConfigsPredicate      predicate.Predicate
 	WatchExternalArtifacts     bool
 	CancelHealthCheckOnRequeue bool
+	EnableDependencyQueueing   bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -154,6 +155,21 @@ func (r *KustomizationReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		enqueueRequestsFromMapFunc = wr.EnqueueRequestsFromMapFunc
 		blder = runtimeCtrl.NewControllerManagedBy(mgr, wr).
 			For(&kustomizev1.Kustomization{}, ksPredicate).Builder
+	}
+
+	if opts.EnableDependencyQueueing {
+		// Index the Kustomizations by the dependsOn references they (may) point at.
+		if err := mgr.GetCache().IndexField(ctx, &kustomizev1.Kustomization{}, dependsOnIndexKey,
+			r.indexDependsOn); err != nil {
+			return fmt.Errorf("failed setting index fields: %w", err)
+		}
+
+		blder = blder.
+			Watches(
+				&kustomizev1.Kustomization{},
+				handler.EnqueueRequestsFromMapFunc(r.requestsForDependents),
+				builder.WithPredicates(KustomizationReadyChangePredicate{}),
+			)
 	}
 
 	blder.

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 			APIReader:                 testEnv,
 			EventRecorder:             testEnv.GetEventRecorderFor(controllerName),
 			Metrics:                   testMetricsH,
-			DependencyRequeueInterval: 2 * time.Second,
+			DependencyRequeueInterval: 2 * time.Hour,
 			ConcurrentSSA:             4,
 			DisallowedFieldManagers:   []string{overrideManagerName},
 			SOPSAgeSecret:             sopsAgeSecret,
@@ -190,6 +190,7 @@ func TestMain(m *testing.M) {
 			WatchConfigsPredicate:      predicate.Not(predicate.Funcs{}),
 			WatchExternalArtifacts:     true,
 			CancelHealthCheckOnRequeue: true,
+			EnableDependencyQueueing:   true,
 		}); err != nil {
 			panic(fmt.Sprintf("Failed to start KustomizationReconciler: %v", err))
 		}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -67,6 +67,11 @@ const (
 	// reports the defaulted field as "field not declared in schema" when
 	// validating managed fields against the old version's schema.
 	MigrateAPIVersion = "MigrateAPIVersion"
+
+	// EnableDependencyQueueing controls whether reconciliation of a kustomization
+	// should be queued once one of its dependencies becomes ready, or if only
+	// time-based retries with requeue-dependency delays should be attempted
+	EnableDependencyQueueing = "EnableDependencyQueueing"
 )
 
 var features = map[string]bool{
@@ -103,6 +108,9 @@ var features = map[string]bool{
 	// MigrateAPIVersion
 	// opt-in from v1.8.4
 	MigrateAPIVersion: false,
+	// EnableDependencyQueueing
+	// opt-in from v1.10
+	EnableDependencyQueueing: false,
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -346,6 +346,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	enableDependencyQueueing, err := features.Enabled(features.EnableDependencyQueueing)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.EnableDependencyQueueing)
+		os.Exit(1)
+	}
+
 	if err = (&controller.KustomizationReconciler{
 		AdditiveCELDependencyCheck: additiveCELDependencyCheck,
 		AllowExternalArtifact:      allowExternalArtifact,
@@ -380,6 +386,7 @@ func main() {
 		WatchConfigsPredicate:      watchConfigsPredicate,
 		WatchExternalArtifacts:     allowExternalArtifact,
 		CancelHealthCheckOnRequeue: cancelHealthCheckOnNewRevision,
+		EnableDependencyQueueing:   enableDependencyQueueing,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", controllerName)
 		os.Exit(1)


### PR DESCRIPTION
Dependents of a kustomization, that are in "wait dependency", status should be reconciled immediately after the dependency becomes ready or is reconciled with a new revision.

This should not make any functional change compared to the current logic, only improve latency compared to current polling of `requeue-dependency`.