### PR TITLE
Add feature gate to cancel health checks on new revisions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fluxcd/pkg/http/fetch v0.19.0
 	github.com/fluxcd/pkg/kustomize v1.22.0
 	github.com/fluxcd/pkg/runtime v0.86.0
-	github.com/fluxcd/pkg/ssa v0.57.0
+	github.com/fluxcd/pkg/ssa v0.58.0
 	github.com/fluxcd/pkg/tar v0.14.0
 	github.com/fluxcd/pkg/testserver v0.13.0
 	github.com/fluxcd/source-controller/api v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/fluxcd/pkg/runtime v0.86.0 h1:q7aBSerJwt0N9hpurPVElG+HWpVhZcs6t96bcNQ
 github.com/fluxcd/pkg/runtime v0.86.0/go.mod h1:Wt9mUzQgMPQMu2D/wKl5pG4zh5vu/tfF5wq9pPobxOQ=
 github.com/fluxcd/pkg/sourceignore v0.14.0 h1:ZiZzbXtXb/Qp7I7JCStsxOlX8ri8rWwCvmvIrJ0UzQQ=
 github.com/fluxcd/pkg/sourceignore v0.14.0/go.mod h1:E3zKvyTyB+oQKqm/2I/jS6Rrt3B7fNuig/4bY2vi3bg=
-github.com/fluxcd/pkg/ssa v0.57.0 h1:G2cKyeyOtEdOdLeMBWZe0XT+J0rBWSBzy9xln2myTaI=
-github.com/fluxcd/pkg/ssa v0.57.0/go.mod h1:iN/QDMqdJaVXKkqwbXqGa4PyWQwtyIy2WkeM2+9kfXA=
+github.com/fluxcd/pkg/ssa v0.58.0 h1:W7m2LQFsZxPN9nn3lfGVDwXsZnIgCWWJ/+/K5hpzW+k=
+github.com/fluxcd/pkg/ssa v0.58.0/go.mod h1:iN/QDMqdJaVXKkqwbXqGa4PyWQwtyIy2WkeM2+9kfXA=
 github.com/fluxcd/pkg/tar v0.14.0 h1:9Gku8FIvPt2bixKldZnzXJ/t+7SloxePlzyVGOK8GVQ=
 github.com/fluxcd/pkg/tar v0.14.0/go.mod h1:+rOWYk93qLEJ8WwmkvJOkB8i0dna1mrwJFybE8i9Udo=
 github.com/fluxcd/pkg/testserver v0.13.0 h1:xEpBcEYtD7bwvZ+i0ZmChxKkDo/wfQEV3xmnzVybSSg=

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -59,6 +59,15 @@ const (
 
 	// ExternalArtifact controls whether the ExternalArtifact source type is enabled.
 	ExternalArtifact = "ExternalArtifact"
+
+	// CancelHealthCheckOnNewRevision controls whether ongoing health checks
+	// should be cancelled when a new source revision becomes available.
+	//
+	// When enabled, if a new revision is detected while waiting for resources
+	// to become ready, the current health check will be cancelled to allow
+	// immediate processing of the new revision. This can help avoid getting
+	// stuck on failing deployments when fixes are available.
+	CancelHealthCheckOnNewRevision = "CancelHealthCheckOnNewRevision"
 )
 
 var features = map[string]bool{
@@ -83,6 +92,9 @@ var features = map[string]bool{
 	// ExternalArtifact
 	// opt-in from v1.7
 	ExternalArtifact: false,
+	// CancelHealthCheckOnNewRevision
+	// opt-in from v1.7
+	CancelHealthCheckOnNewRevision: false,
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -293,6 +293,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	cancelHealthCheckOnNewRevision, err := features.Enabled(features.CancelHealthCheckOnNewRevision)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.CancelHealthCheckOnNewRevision)
+		os.Exit(1)
+	}
+
 	var tokenCache *pkgcache.TokenCache
 	if tokenCacheOptions.MaxSize > 0 {
 		var err error
@@ -307,29 +313,30 @@ func main() {
 	}
 
 	if err = (&controller.KustomizationReconciler{
-		AdditiveCELDependencyCheck: additiveCELDependencyCheck,
-		AllowExternalArtifact:      allowExternalArtifact,
-		APIReader:                  mgr.GetAPIReader(),
-		ArtifactFetchRetries:       httpRetry,
-		Client:                     mgr.GetClient(),
-		ClusterReader:              clusterReader,
-		ConcurrentSSA:              concurrentSSA,
-		ControllerName:             controllerName,
-		DefaultServiceAccount:      defaultServiceAccount,
-		DependencyRequeueInterval:  requeueDependency,
-		DisallowedFieldManagers:    disallowedFieldManagers,
-		EventRecorder:              eventRecorder,
-		FailFast:                   failFast,
-		GroupChangeLog:             groupChangeLog,
-		KubeConfigOpts:             kubeConfigOpts,
-		Mapper:                     restMapper,
-		Metrics:                    metricsH,
-		NoCrossNamespaceRefs:       aclOptions.NoCrossNamespaceRefs,
-		NoRemoteBases:              noRemoteBases,
-		SOPSAgeSecret:              sopsAgeSecret,
-		StatusManager:              fmt.Sprintf("gotk-%s", controllerName),
-		StrictSubstitutions:        strictSubstitutions,
-		TokenCache:                 tokenCache,
+		AdditiveCELDependencyCheck:     additiveCELDependencyCheck,
+		AllowExternalArtifact:          allowExternalArtifact,
+		CancelHealthCheckOnNewRevision: cancelHealthCheckOnNewRevision,
+		APIReader:                      mgr.GetAPIReader(),
+		ArtifactFetchRetries:           httpRetry,
+		Client:                         mgr.GetClient(),
+		ClusterReader:                  clusterReader,
+		ConcurrentSSA:                  concurrentSSA,
+		ControllerName:                 controllerName,
+		DefaultServiceAccount:          defaultServiceAccount,
+		DependencyRequeueInterval:      requeueDependency,
+		DisallowedFieldManagers:        disallowedFieldManagers,
+		EventRecorder:                  eventRecorder,
+		FailFast:                       failFast,
+		GroupChangeLog:                 groupChangeLog,
+		KubeConfigOpts:                 kubeConfigOpts,
+		Mapper:                         restMapper,
+		Metrics:                        metricsH,
+		NoCrossNamespaceRefs:           aclOptions.NoCrossNamespaceRefs,
+		NoRemoteBases:                  noRemoteBases,
+		SOPSAgeSecret:                  sopsAgeSecret,
+		StatusManager:                  fmt.Sprintf("gotk-%s", controllerName),
+		StrictSubstitutions:            strictSubstitutions,
+		TokenCache:                     tokenCache,
 	}).SetupWithManager(ctx, mgr, controller.KustomizationReconcilerOptions{
 		RateLimiter:            runtimeCtrl.GetRateLimiter(rateLimiterOptions),
 		WatchConfigsPredicate:  watchConfigsPredicate,


### PR DESCRIPTION
This PR introduces the feature gate `CancelHealthCheckOnNewRevision` for allowing health checks to be cancelled earlier in case a new revision of the source is observed.

Co-authored-by: @trashhalo (xref: https://github.com/fluxcd/kustomize-controller/pull/1518)
Includes: https://github.com/fluxcd/pkg/pull/1033