### PR TITLE
Add x-kubernetes annotations to Kustomization CRD

### DIFF
--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -29,6 +29,10 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
+        x-kubernetes-group-version-kind:
+          - group: "kustomize.toolkit.fluxcd.io"
+            kind: "Kustomization"
+            version: "v1"
         description: Kustomization is the Schema for the kustomizations API.
         properties:
           apiVersion:
@@ -75,6 +79,8 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
+                x-kubernetes-patch-strategy: merge
               decryption:
                 description: Decrypt Kubernetes secrets before applying them on the
                   cluster.


### PR DESCRIPTION
This allows `components` lists to be merged instead of replaced when applying a strategic merge patch to a flux Kustomization resource, as long as the OpenAPI schema is provided to Kustomize. (The same approach can be applied to other fields and CRDs)

Example:
ks.yaml:
```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1
kind: Kustomization
metadata:
  name: podinfo
  namespace: default
spec:
  interval: 10m
  targetNamespace: default
  components: [ "../original" ]
  sourceRef:
    kind: GitRepository
    name: podinfo
  path: "./kustomize"
  prune: true
  timeout: 1m
```

kustomization.yaml:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - ks.yaml

openapi:
  path: https://raw.githubusercontent.com/m00nwtchr/flux2-schemas/refs/heads/m00nwtchr-patch-1/_definitions.json
    
patches:
  - target:
      kind: Kustomization
      version: v1
      group: kustomize.toolkit.fluxcd.io
    patch: |-
      apiVersion: kustomize.toolkit.fluxcd.io/v1
      kind: Kustomization
      metadata:
        name: not-used
      spec:
        components:
          - "../patch"
```