### PR TITLE
Add GVK to post-build error message

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -771,7 +771,7 @@ func (r *KustomizationReconciler) build(ctx context.Context,
 		if obj.Spec.Decryption != nil {
 			outRes, err := dec.DecryptResource(res)
 			if err != nil {
-				return nil, fmt.Errorf("decryption failed for '%s': %w", res.GetName(), err)
+				return nil, fmt.Errorf("decryption failed for '%s/%s': %w", res.GetGvk(), res.GetName(), err)
 			}
 
 			if outRes != nil {
@@ -787,7 +787,7 @@ func (r *KustomizationReconciler) build(ctx context.Context,
 			outRes, err := generator.SubstituteVariables(ctx, r.Client, u, res,
 				generator.SubstituteWithStrict(r.StrictSubstitutions))
 			if err != nil {
-				return nil, fmt.Errorf("post build failed for '%s': %w", res.GetName(), err)
+				return nil, fmt.Errorf("post build failed for '%s/%s': %w", res.GetGvk(), res.GetName(), err)
 			}
 
 			if outRes != nil {


### PR DESCRIPTION
We recently had a syntax error in an env substitution, but all we saw in the cluster was
```
post build failed for '${NAME}': envsubst error: variable substitution failed: unable to parse variable name
```

because in the manifest we used templated the resource name:
```yaml
metadata:
  name: ${NAME}
```

The error was quite confusing in that case. In general, the resource name itself might not be enough to pin-point an issue, since is is common to have the same name across e.g. a Deployment and a Service.