### PR TITLE
Add annotation to disable decryption on a per object basis

### DIFF
--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -1264,6 +1264,18 @@ data:
   sops.vault-token: <BASE64>
 ```
 
+#### Controlling the decryption behavior of resources
+
+To change the decryption behaviour for specific Kubernetes resources, you can annotate them with:
+
+| Annotation                          | Default    | Values                                                         | Role            |
+|-------------------------------------|------------|----------------------------------------------------------------|-----------------|
+| `kustomize.toolkit.fluxcd.io/decrypt` | `Enabled` | - `Enabled`<br/>- `Disabled`                                   | Decryption policy |
+
+##### Disabled
+
+The `Disabled` policy instructs the controller to not decrypt Kubernetes resources. This might be useful if there is another entity that is going to decrpyt the resource later.
+
 ## Working with Kustomizations
 
 ### Recommended settings

--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -890,7 +890,7 @@ func (r *KustomizationReconciler) apply(ctx context.Context,
 	}
 
 	for _, u := range objects {
-		if decryptor.IsEncryptedSecret(u) {
+		if decryptor.IsEncryptedSecret(u) && !decryptor.IsDecryptionDisabled(u.GetAnnotations()) {
 			return false, nil,
 				fmt.Errorf("%s is SOPS encrypted, configuring decryption is required for this secret to be reconciled",
 					ssautil.FmtUnstructured(u))

--- a/internal/decryptor/decryptor_test.go
+++ b/internal/decryptor/decryptor_test.go
@@ -632,7 +632,17 @@ func TestDecryptor_DecryptResource(t *testing.T) {
 		g.Expect(secret.UnmarshalJSON(encData)).To(Succeed())
 		g.Expect(isSOPSEncryptedResource(secret)).To(BeTrue())
 
+		secret.SetAnnotations(map[string]string{
+			"kustomize.toolkit.fluxcd.io/decrypt": "disabled",
+		})
+
 		got, err := d.DecryptResource(secret)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).To(BeNil())
+
+		secret.SetAnnotations(map[string]string{})
+
+		got, err = d.DecryptResource(secret)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got.MarshalJSON()).To(Equal(secretData))


### PR DESCRIPTION
As discussed in https://github.com/fluxcd/flux2/discussions/5612, this PR implements the `kustomize.toolkit.fluxcd.io/decrypt` annotation to disable decryption on a per object basis. This is necessary if decryption happens in the cluster at some later point in time, e.g. for `SopsSecrets`.