### PR TITLE
Requeue on cancellation to avoid stale cache race condition

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -282,7 +282,12 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.event(obj, revision, originRevision, eventv1.EventSeverityInfo,
 			fmt.Sprintf("Health checks canceled due to new reconciliation triggered by %s/%s/%s",
 				qes.Kind, qes.Namespace, qes.Name), nil)
-		return ctrl.Result{}, nil
+
+		// Requeue immediately to ensure the object is reconciled against the new revision in the eventuality
+		// of stale runtime cache that would cause the source predicate filter to drop the reconcile request.
+		// In the case where the cache is fresh and the object is already in the queue, the new reconcile request
+		// will be dropped by the controller runtime dedupe logic, so we don't risk reconciling twice the same revision.
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Broadcast the reconciliation failure and requeue at the specified retry interval.


### PR DESCRIPTION
Handle health check cancellation by requeuing immediately to ensure the object is reconciled against the new revision in the eventuality of stale runtime cache that would cause the source predicate filter to drop the reconcile request.

**Note** that there is no proof that the requests gets dropped from the queue after the cancelation is triggered, so this "fix" may not do anything. I was not able to reproduce in envtest this issue as the cache doesn't become stale (this requires flaky network or etcd pressure). The scenario I'm relying on is:

```
  Rapid commits cause stale cache scenario:                              
                                                          
  1. 124a229e reconcile → health check → cancelled by V_new dispatch                                                                                                         
  2. Old code: ctrl.Result{}, nil. Dispatch item in queue.
  3. Worker picks up dispatch item → getSource → stale cache → 124a229e → build/apply (no-op)                                                                                
  4. During build/apply, ANOTHER dispatch fires (V_newer) → interrupt context cancelled                                                                                      
  5. checkHealth → already cancelled → returns *QueueEventSource                                                                                                             
  6. Reconcile() → HealthCheckCanceled → ctrl.Result{}, nil (old code)                                                                                                       
  7. V_newer dispatch item in queue                                                                                                                                          
  8. Repeat from step 3... until eventually no more dispatches, but by then ctrl.Result{}, nil means no requeue                                                              
  9. STUCK                                                                                                                                                                   
                                                          
The rapid commits keep cancelling each stale-cache reconcile. Eventually the commits stop, but the LAST cancellation returns ctrl.Result{}, nil with no requeue.
The source cache has caught up, but nothing triggers a reconcile.
                                                                                                                                                                             
Requeue: true breaks the cycle: even after the last cancellation, a requeue fires, the source cache has V_final, the reconcile applies it, health checks pass. 
```

PS. In the case where the cache is fresh and the object is already in the queue, the new reconcile request will be dropped by the controller runtime dedupe logic, so we don't risk reconciling twice the same revision.

Preview image for testing: `ghcr.io/fluxcd/kustomize-controller:rc-203b42e7`


Fix: #1624