### PR TITLE
chore: typo `unneccessary` -> `unnecessary` in fuzzer test comment

### DIFF
--- a/internal/controller/kustomization_fuzzer_test.go
+++ b/internal/controller/kustomization_fuzzer_test.go
@@ -263,7 +263,7 @@ func Fuzz_Controllers(f *testing.F) {
 			}
 
 			// ensure the deferred deletion of all objects (namespace, secret, sopSecret) and
-			// the kustomization above were reconciled before moving on. This avoids unneccessary
+			// the kustomization above were reconciled before moving on. This avoids unnecessary
 			// errors whilst tearing down the testing infrastructure.
 			time.Sleep(10 * time.Second)
 


### PR DESCRIPTION
One-character typo fix inside `internal/controller/kustomization_fuzzer_test.go:266` (comment about tearing down testing infrastructure). No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>