### PR TITLE
docs: add debugging tips to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,3 +92,43 @@ make deploy
 ```
 
 Running the above will also deploy `source-controller` and its CRDs to the cluster.
+
+## Debugging the controller locally
+
+When reproducing an issue or stepping through reconciliation logic, the
+following knobs make local runs cheaper and the resulting logs easier to
+read.
+
+### Limit the watched namespace
+
+The controller watches every namespace by default. To narrow it to a single
+namespace, set the `RUNTIME_NAMESPACE` environment variable before invoking
+`make run`:
+
+```sh
+RUNTIME_NAMESPACE=flux-system make run
+```
+
+### Reduce reconcile concurrency
+
+Each `Kustomization` reconcile is processed concurrently (default
+`--concurrent=4`, plus an independent `--concurrent-ssa=4` for server-side
+apply). When debugging it is almost always easier to follow a serial
+trace; pass `--concurrent=1 --concurrent-ssa=1` so reconciles and SSA
+operations run one at a time:
+
+```sh
+go run ./main.go --concurrent=1 --concurrent-ssa=1
+```
+
+### Suspend unrelated objects
+
+If the controller is sharing a cluster with other Flux objects, suspend
+anything not relevant to the test you're running so their reconciles don't
+interleave with yours:
+
+```sh
+flux suspend kustomization <name>
+```
+
+Resume with `flux resume kustomization <name>` when you're done.


### PR DESCRIPTION
## Summary
Adds a 'Debugging the controller locally' section to `DEVELOPMENT.md` covering knobs not already in 'How to run the controller locally':

- `RUNTIME_NAMESPACE` to scope the watch
- `--concurrent=1 --concurrent-ssa=1` to serialize reconciles and SSA for a clean trace
- `flux suspend kustomization` for unrelated objects sharing the cluster

Cross-controller setup with source-controller (port-forward + `SOURCE_CONTROLLER_LOCALHOST`) is already documented under 'How to run the controller locally' and is not duplicated here.

Assisted-by: Claude/claude-opus-4-7