### PR TITLE
build: target host arch for local builds/envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,13 @@ GO_TEST_ARGS ?=
 
 # Allows for defining additional Docker buildx arguments, e.g. '--push'.
 BUILD_ARGS ?= --load
-# Architectures to build images for.
-BUILD_PLATFORMS ?= linux/amd64
+# Host architecture, used so local builds and envtest target the host.
+LOCALARCH ?= $(shell go env GOARCH)
+# Architectures to build images for; defaults to the host architecture.
+BUILD_PLATFORMS ?= linux/$(LOCALARCH)
 
-# Architecture to use envtest with
-ENVTEST_ARCH ?= amd64
+# Architecture to use envtest with; defaults to the host architecture.
+ENVTEST_ARCH ?= $(LOCALARCH)
 
 # Paths to download the CRD dependencies at.
 GITREPO_CRD ?= config/crd/bases/gitrepositories.yaml


### PR DESCRIPTION
On arm64 hosts, builds would use amd64 for both:
- `ENVTEST_ARCH` test binaries
- `BUILD_PLATFORMS` for `make docker-build`

So local builds and tests run under emulation (Rosetta) on arm64 hosts, which is slow and occasionally hides subtle runtime bugs like the ones i ran into testing helm-controller. envtest publishes native arm64 binaries now (including darwin/arm64), so the pin and Darwin override is no longer needed.

now:
- `ENVTEST_ARCH` follows the host arch
- `BUILD_PLATFORMS` defaults to `linux/<host arch>` so `make docker-build` makes a native image

overrides still work:
`make docker-build BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7`

Multi-arch release images come from the fluxcd/gha-workflows release flow, not `make docker-build`, so release artifacts are untouched.
I ran all tests and docker-builds across the 9 repos via apple silicon

tracking: https://github.com/fluxcd/flux2/issues/5931