### PR TITLE
fix: keep failed-to-prune resources in status.Inventory (#1664)

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -498,7 +498,11 @@ func (r *KustomizationReconciler) reconcile(
 	}
 
 	// Run garbage collection for stale resources that do not have pruning disabled.
-	if _, err := r.prune(ctx, resourceManager, obj, revision, originRevision, staleObjects); err != nil {
+	// On failure, re-track the objects whose DELETE wasn't confirmed so that the
+	// next reconcile retries — otherwise status.Inventory advances past them
+	// and they leak as untracked orphans (issue #1664).
+	if _, survivors, err := r.prune(ctx, resourceManager, obj, revision, originRevision, staleObjects); err != nil {
+		inventory.Merge(obj.Status.Inventory, survivors)
 		obj.Status.History.Upsert(checksum, time.Now(), time.Since(reconcileStart), meta.PruneFailedReason, historyMeta)
 		conditions.MarkFalse(obj, meta.ReadyCondition, meta.PruneFailedReason, "%s", err)
 		return err
@@ -1080,31 +1084,69 @@ func (r *KustomizationReconciler) checkHealth(ctx context.Context,
 	return nil
 }
 
+// prune issues delete requests for the given stale objects. In addition to the
+// changed/error return, it returns the slice of objects whose deletion was NOT
+// confirmed by the apiserver (e.g. rejected by an admission webhook). Callers
+// must merge those survivors back into status.Inventory; otherwise the next
+// reconcile's old-vs-new diff will not surface them again and they become
+// untracked orphans labeled with this Kustomization. See issue #1664.
 func (r *KustomizationReconciler) prune(ctx context.Context,
 	manager *ssa.ResourceManager,
 	obj *kustomizev1.Kustomization,
 	revision string,
 	originRevision string,
-	objects []*unstructured.Unstructured) (bool, error) {
+	objects []*unstructured.Unstructured) (bool, []*unstructured.Unstructured, error) {
 	if !obj.Spec.Prune {
-		return false, nil
+		return false, nil, nil
 	}
 
 	log := ctrl.LoggerFrom(ctx)
 
 	changeSet, err := deleteObjects(ctx, obj, manager, objects)
 	if err != nil {
-		return false, err
+		// Identify objects whose DELETE wasn't confirmed (apiserver rejected,
+		// transient error, etc.) so the caller can re-track them. SkippedAction
+		// entries are intentional opt-outs (kustomize.toolkit.fluxcd.io/prune:
+		// disabled) and are treated as settled, otherwise we'd cause an endless
+		// retry of a delete the operator explicitly disabled.
+		return false, pruneSurvivors(objects, changeSet), err
 	}
 
 	// emit event only if the prune operation resulted in changes
 	if changeSet != nil && len(changeSet.Entries) > 0 {
 		log.Info(fmt.Sprintf("garbage collection completed: %s", changeSet.String()))
 		r.event(obj, revision, originRevision, eventv1.EventSeverityInfo, changeSet.String(), nil)
-		return true, nil
+		return true, nil, nil
 	}
 
-	return false, nil
+	return false, nil, nil
+}
+
+// pruneSurvivors returns the subset of objects whose DELETE was not confirmed
+// by the apiserver — i.e. objects without a corresponding DeletedAction or
+// SkippedAction entry in the returned ChangeSet. These should be re-merged into
+// status.Inventory so subsequent reconciles retry their prune. See #1664.
+func pruneSurvivors(objects []*unstructured.Unstructured, changeSet *ssa.ChangeSet) []*unstructured.Unstructured {
+	if len(objects) == 0 {
+		return nil
+	}
+	settled := make(map[string]bool)
+	if changeSet != nil {
+		for _, entry := range changeSet.Entries {
+			switch entry.Action {
+			case ssa.DeletedAction, ssa.SkippedAction:
+				settled[entry.ObjMetadata.String()] = true
+			}
+		}
+	}
+	var survivors []*unstructured.Unstructured
+	for _, obj := range objects {
+		id := object.UnstructuredToObjMetadata(obj).String()
+		if !settled[id] {
+			survivors = append(survivors, obj)
+		}
+	}
+	return survivors
 }
 
 // finalizerShouldDeleteResources determines if resources should be deleted

--- a/internal/controller/kustomization_prune_survivors_test.go
+++ b/internal/controller/kustomization_prune_survivors_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/fluxcd/pkg/ssa"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func newCM(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"})
+	u.SetName(name)
+	u.SetNamespace("default")
+	return u
+}
+
+func entry(u *unstructured.Unstructured, action ssa.Action) ssa.ChangeSetEntry {
+	return ssa.ChangeSetEntry{
+		ObjMetadata:  object.UnstructuredToObjMetadata(u),
+		GroupVersion: u.GroupVersionKind().Version,
+		Action:       action,
+	}
+}
+
+// Regression test for #1664. When prune partially fails — e.g. an admission
+// webhook denies some deletes — the surviving objects must be returned so the
+// reconciler can re-merge them into status.Inventory and retry on the next
+// reconcile. Without this, the orphans become permanently untracked.
+func TestPruneSurvivors(t *testing.T) {
+	g := NewWithT(t)
+
+	a, b, c := newCM("a"), newCM("b"), newCM("c")
+	objects := []*unstructured.Unstructured{a, b, c}
+
+	t.Run("nil changeset preserves all objects on failure path", func(t *testing.T) {
+		out := pruneSurvivors(objects, nil)
+		g.Expect(out).To(HaveLen(3))
+	})
+
+	t.Run("deleted and skipped actions are settled", func(t *testing.T) {
+		cs := ssa.NewChangeSet()
+		cs.Add(entry(a, ssa.DeletedAction))
+		cs.Add(entry(b, ssa.SkippedAction))
+		// c missing from the changeset → not settled → survivor.
+		out := pruneSurvivors(objects, cs)
+		g.Expect(out).To(HaveLen(1))
+		g.Expect(out[0].GetName()).To(Equal("c"))
+	})
+
+	t.Run("unknown action means delete was rejected — must survive", func(t *testing.T) {
+		cs := ssa.NewChangeSet()
+		cs.Add(entry(a, ssa.DeletedAction))
+		cs.Add(entry(b, ssa.UnknownAction)) // webhook denied / apiserver error
+		cs.Add(entry(c, ssa.UnknownAction))
+		out := pruneSurvivors(objects, cs)
+		names := []string{}
+		for _, o := range out {
+			names = append(names, o.GetName())
+		}
+		g.Expect(names).To(ConsistOf("b", "c"))
+	})
+
+	t.Run("empty input is empty output", func(t *testing.T) {
+		g.Expect(pruneSurvivors(nil, nil)).To(BeEmpty())
+		g.Expect(pruneSurvivors([]*unstructured.Unstructured{}, ssa.NewChangeSet())).To(BeEmpty())
+	})
+}

--- a/internal/controller/kustomization_prune_test.go
+++ b/internal/controller/kustomization_prune_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -163,6 +165,165 @@ data:
 	t.Run("preserves objects with pruning disabled", func(t *testing.T) {
 		g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(resultConfig), resultConfig)).Should(Succeed())
 	})
+}
+
+func TestKustomizationReconciler_PruneFailedInventoryRetry(t *testing.T) {
+	g := NewWithT(t)
+	id := "gc-" + randStringRunes(5)
+	revision := "v1.0.0"
+
+	err := createNamespace(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+	manifests := func(name string) []testserver.File {
+		return []testserver.File{
+			{
+				Name: "config.yaml",
+				Body: fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s
+data:
+  key: value
+`, name),
+			},
+		}
+	}
+
+	artifact, err := testServer.ArtifactFromFiles(manifests(id))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	repositoryName := types.NamespacedName{
+		Name:      fmt.Sprintf("gc-%s", randStringRunes(5)),
+		Namespace: id,
+	}
+	g.Expect(applyGitRepository(repositoryName, artifact, revision)).To(Succeed())
+
+	kustomization := &kustomizev1.Kustomization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("gc-%s", randStringRunes(5)),
+			Namespace: id,
+		},
+		Spec: kustomizev1.KustomizationSpec{
+			Interval: metav1.Duration{Duration: reconciliationInterval},
+			Path:     "./",
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Name:      repositoryName.Name,
+				Namespace: repositoryName.Namespace,
+				Kind:      sourcev1.GitRepositoryKind,
+			},
+			TargetNamespace: id,
+			Prune:           true,
+		},
+	}
+
+	g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
+
+	resultK := &kustomizev1.Kustomization{}
+	g.Eventually(func() bool {
+		_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+		return resultK.Status.LastAppliedRevision == revision
+	}, timeout, time.Second).Should(BeTrue())
+	g.Expect(resultK.Status.Inventory.Entries).To(HaveLen(1))
+
+	cmKey := types.NamespacedName{Name: id, Namespace: id}
+	g.Expect(k8sClient.Get(context.Background(), cmKey, &corev1.ConfigMap{})).To(Succeed())
+
+	t.Run("accepted delete leaves inventory", func(t *testing.T) {
+		got := &corev1.ConfigMap{}
+		g.Expect(k8sClient.Get(context.Background(), cmKey, got)).To(Succeed())
+		got.SetFinalizers([]string{"test.finalizers.fluxcd.io/block"})
+		g.Expect(k8sClient.Update(context.Background(), got)).To(Succeed())
+
+		artifact, err := testServer.ArtifactFromFiles(nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		revision = "v2.0.0"
+		g.Expect(applyGitRepository(repositoryName, artifact, revision)).To(Succeed())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			return resultK.Status.LastAppliedRevision == revision
+		}, timeout, time.Second).Should(BeTrue())
+		g.Expect(resultK.Status.Inventory.Entries).To(BeEmpty())
+
+		g.Expect(k8sClient.Get(context.Background(), cmKey, got)).To(Succeed())
+		g.Expect(got.GetDeletionTimestamp()).ToNot(BeNil())
+
+		got.SetFinalizers(nil)
+		g.Expect(k8sClient.Update(context.Background(), got)).To(Succeed())
+		g.Eventually(func() bool {
+			err := k8sClient.Get(context.Background(), cmKey, &corev1.ConfigMap{})
+			return apierrors.IsNotFound(err)
+		}, timeout, time.Second).Should(BeTrue())
+	})
+
+	t.Run("rejected delete stays in inventory until retry succeeds", func(t *testing.T) {
+		artifact, err := testServer.ArtifactFromFiles(manifests(id))
+		g.Expect(err).NotTo(HaveOccurred())
+		revision = "v3.0.0"
+		g.Expect(applyGitRepository(repositoryName, artifact, revision)).To(Succeed())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			return resultK.Status.LastAppliedRevision == revision
+		}, timeout, time.Second).Should(BeTrue())
+		g.Expect(resultK.Status.Inventory.Entries).To(HaveLen(1))
+
+		originalClient := reconciler.Client
+		failDelete := &failingDeleteClient{
+			Client: originalClient,
+			key:    cmKey,
+		}
+		failDelete.block.Store(true)
+		reconciler.Client = failDelete
+		defer func() {
+			reconciler.Client = originalClient
+		}()
+
+		artifact, err = testServer.ArtifactFromFiles(nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		revision = "v4.0.0"
+		g.Expect(applyGitRepository(repositoryName, artifact, revision)).To(Succeed())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			ready := apimeta.FindStatusCondition(resultK.Status.Conditions, meta.ReadyCondition)
+			return ready != nil && ready.Status == metav1.ConditionFalse && ready.Reason == meta.PruneFailedReason
+		}, timeout, time.Second).Should(BeTrue())
+		g.Expect(resultK.Status.Inventory.Entries).To(HaveLen(1))
+
+		got := &corev1.ConfigMap{}
+		g.Expect(k8sClient.Get(context.Background(), cmKey, got)).To(Succeed())
+		g.Expect(got.GetDeletionTimestamp()).To(BeNil())
+
+		failDelete.block.Store(false)
+
+		g.Eventually(func() bool {
+			err := k8sClient.Get(context.Background(), cmKey, &corev1.ConfigMap{})
+			return apierrors.IsNotFound(err)
+		}, timeout, time.Second).Should(BeTrue())
+
+		g.Eventually(func() bool {
+			_ = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(kustomization), resultK)
+			return resultK.Status.LastAppliedRevision == revision && len(resultK.Status.Inventory.Entries) == 0
+		}, timeout, time.Second).Should(BeTrue())
+	})
+}
+
+type failingDeleteClient struct {
+	client.Client
+	key   types.NamespacedName
+	block atomic.Bool
+}
+
+func (c *failingDeleteClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if c.block.Load() &&
+		obj.GetObjectKind().GroupVersionKind().Kind == "ConfigMap" &&
+		client.ObjectKeyFromObject(obj) == c.key {
+		return fmt.Errorf("injected delete failure")
+	}
+	return c.Client.Delete(ctx, obj, opts...)
 }
 
 func TestKustomizationReconciler_PruneEmpty(t *testing.T) {

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -51,6 +51,31 @@ func AddChangeSet(inv *kustomizev1.ResourceInventory, set *ssa.ChangeSet) error 
 	return nil
 }
 
+// Merge appends the given objects to the inventory unless they already exist.
+// Used to re-track resources whose prune was rejected by the apiserver
+// (e.g. by an admission webhook) so that subsequent reconciles retry the
+// deletion instead of leaving them as untracked orphans.
+func Merge(inv *kustomizev1.ResourceInventory, objects []*unstructured.Unstructured) {
+	if inv == nil || len(objects) == 0 {
+		return
+	}
+	seen := make(map[string]bool, len(inv.Entries))
+	for _, e := range inv.Entries {
+		seen[e.ID] = true
+	}
+	for _, obj := range objects {
+		id := object.UnstructuredToObjMetadata(obj).String()
+		if seen[id] {
+			continue
+		}
+		inv.Entries = append(inv.Entries, kustomizev1.ResourceRef{
+			ID:      id,
+			Version: obj.GroupVersionKind().Version,
+		})
+		seen[id] = true
+	}
+}
+
 // List returns the inventory entries as unstructured.Unstructured objects.
 func List(inv *kustomizev1.ResourceInventory) ([]*unstructured.Unstructured, error) {
 	objects := make([]*unstructured.Unstructured, 0)

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -65,6 +65,33 @@ func Test_Inventory(t *testing.T) {
 		g.Expect(len(unList)).To(BeIdenticalTo(1))
 		g.Expect(unList[0].GetName()).To(BeIdenticalTo("test2"))
 	})
+
+	t.Run("merge re-adds objects whose prune failed", func(t *testing.T) {
+		// Simulates what reconcile does after a failed prune. Treat inv2 (the
+		// inventory with test2) as the OLD state and inv1 (without test2) as
+		// the NEW state — i.e. test2 is the stale object the operator removed
+		// from git and Flux failed to prune. Merge must put it back into the
+		// new inventory so the next reconcile retries.
+		stale, err := Diff(inv2, inv1)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(len(stale)).To(BeIdenticalTo(1))
+		g.Expect(stale[0].GetName()).To(BeIdenticalTo("test2"))
+
+		merged := New()
+		merged.Entries = append(merged.Entries, inv1.Entries...)
+		before := len(merged.Entries)
+		Merge(merged, stale)
+		g.Expect(len(merged.Entries)).To(BeIdenticalTo(before + 1))
+
+		// Idempotent: a second call must not duplicate entries.
+		Merge(merged, stale)
+		g.Expect(len(merged.Entries)).To(BeIdenticalTo(before + 1))
+	})
+
+	t.Run("merge is nil-safe", func(t *testing.T) {
+		Merge(nil, nil)
+		Merge(inv1, nil)
+	})
 }
 
 func readManifest(manifest string) (*ssa.ChangeSet, error) {


### PR DESCRIPTION
## Summary

Fixes #1664. When `status.Inventory` is advanced to the new build output before the prune step succeeds, and prune subsequently fails because the apiserver rejects the DELETE (admission webhook denial, in-use resource, etc.), the stale resources are silently lost from Flux's tracking. They:

- are no longer in `status.Inventory`,
- still carry the `kustomize.toolkit.fluxcd.io/name=…` label,
- are not surfaced as prunable by the next reconcile's old-vs-new diff (the "old" snapshot has already advanced past them),
- cannot be re-pruned by `flux reconcile` — only manual `kubectl delete` removes them.

Result: long-lived orphans labeled by the `Kustomization` but invisible to its GC.

## Behaviour change

`prune()` now also returns the slice of *survivor* objects whose DELETE wasn't confirmed (no `DeletedAction` or `SkippedAction` `ChangeSetEntry`). The reconcile path merges those survivors back into `status.Inventory` immediately before recording `PruneFailedReason` and returning the error. The next reconcile then sees them in the diff again and retries the prune.

Treating `SkippedAction` entries as settled means resources explicitly opted out (`kustomize.toolkit.fluxcd.io/prune: disabled`) are **not** re-tracked — keeping them would create an infinite retry loop for opt-outs.

Paths NOT affected:
- `spec.prune: false` — `prune()` short-circuits before any of the new logic runs.
- The finalizer path (Kustomization deletion) uses `deleteObjects` directly, not `prune()`.
- Successful prunes — `survivors` is empty, no merge occurs.

## Reproducer

I built a minimal kind-based reproducer at https://github.com/gecube/flux-kc-1664-repro. The relevant variant — `repro-restart-matrix.sh` scenario `webhook-deny-delete` — reproduces the exact production state from #1664 (3/3 consecutive runs): per-AZ ConfigMaps survive past the consolidation commit, `deletionTimestamp` not set, `status.Inventory` already advanced past them. With this patch applied to a locally-built `kustomize-controller`, the same reproducer should leave the orphans in inventory and retry prune on the next reconcile (I have not yet rebuilt-and-loaded a custom controller image into kind to verify end-to-end; happy to do so if useful before merge).

## Tests

- `internal/inventory`: new subtest `merge_re-adds_objects_whose_prune_failed` plus a nil-safety subtest.
- `internal/controller`: new file `kustomization_prune_survivors_test.go` with unit-level coverage of `pruneSurvivors` across the `DeletedAction` / `SkippedAction` / `UnknownAction` / missing-entry cases.
- Existing tests pass locally:
  - `go test ./internal/inventory/...`
  - `go test ./internal/controller/... -run "Prune|Inventory|DeletionPolicy"`
- `go vet ./...` clean, `gofmt -l` clean.

## Notes for maintainers

Marking this **draft** because:

1. I haven't yet end-to-end-tested with a custom-built controller image against the kind reproducer (only unit-tested the new functions). Happy to do so before merge.
2. There may be an alternative design you'd prefer — e.g. tracking the failed-prune subset separately in `status` (under `staleResources` or similar) rather than merging back into inventory; or surfacing an additional `OrphanedResourcesDetected` condition; or a different stance on `SkippedAction` re-tracking semantics. I picked the smallest change that restores GC convergence.
3. The `SkippedAction` case is the subtle one — could you confirm my reading that an explicit `prune: disabled` opt-out should never end up in `survivors`? If you'd rather treat skipped-as-survivor, the change is a one-line swap.

Reviews welcome. Test plan after rebuild verification:

- [x] unit tests for `pruneSurvivors` and `inventory.Merge`
- [x] existing prune / inventory / deletion-policy tests pass locally
- [ ] full local repro with rebuilt image (will run if useful)
- [ ] CI green