### PR TITLE
fix: reject incomplete Azure KV auth

### DIFF
--- a/internal/sops/azkv/config.go
+++ b/internal/sops/azkv/config.go
@@ -100,6 +100,7 @@ func TokenCredentialFromAADConfig(c AADConfig) (token azcore.TokenCredential, er
 				},
 			})
 		}
+		return nil, fmt.Errorf("invalid data: requires 'clientSecret' or 'clientCertificate' when both 'tenantId' and 'clientId' are set")
 	}
 
 	switch {

--- a/internal/sops/azkv/config_test.go
+++ b/internal/sops/azkv/config_test.go
@@ -153,6 +153,14 @@ func TestTokenFromAADConfig(t *testing.T) {
 			},
 			want: &azidentity.ManagedIdentityCredential{},
 		},
+		{
+			name: "Incomplete Service Principal does not fall back to Managed Identity",
+			config: AADConfig{
+				TenantID: "some-tenant-id",
+				ClientID: "some-client-id",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This fixes a small Azure Key Vault auth bug.

An incomplete `sops.azure-kv` config with `tenantId` and `clientId`, but no `clientSecret` or `clientCertificate`, was slipping into the managed identity path. That hides a bad secret and picks the wrong auth mode.

The fix makes that config fail fast. `clientId` only still uses managed identity, so existing MI setups keep working.

Repro:
1. Create a decryption secret with:
   ```yaml
   sops.azure-kv: |
     tenantId: some-tenant-id
     clientId: some-client-id
   ```
2. Before this patch, `TokenCredentialFromAADConfig` returns `*azidentity.ManagedIdentityCredential` and no error.
3. After this patch, it returns an error.

Validation:
`make tidy fmt vet && make test`
