### PR TITLE
Enable `StrictPostBuildSubstitutions` by default

### DIFF
--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -822,11 +822,6 @@ will print out `${var}`.
 All the undefined variables in the format `${var}` will be substituted with an
 empty string unless a default value is provided e.g. `${var:=default}`.
 
-**Note:** It is recommended to set the `--feature-gates=StrictPostBuildSubstitutions=true`
-controller flag, so that the post-build substitutions will fail if a
-variable without a default value is declared in files but is
-missing from the input vars.
-
 You can disable the variable substitution for certain resources by either
 labelling or annotating them with:
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -80,8 +80,8 @@ var features = map[string]bool{
 	// opt-in from v1.1
 	DisableFailFastBehavior: false,
 	// StrictPostBuildSubstitutions
-	// opt-in from v1.3
-	StrictPostBuildSubstitutions: false,
+	// opt-out from v1.9
+	StrictPostBuildSubstitutions: true,
 	// GroupChangeLog
 	// opt-in from v1.5
 	GroupChangeLog: false,


### PR DESCRIPTION
You always want kustomize-controller to alert you if you forget to add a value for a substitution variable, even if the value must be explicitly set to the empty string. Tests were added here to confirm that variables explicitly set to empty string behave the same as omitted variables: https://github.com/fluxcd/pkg/pull/1246/changes/2cd36cba113a8f5a569eea7285c1e3f3c9458e23