### PR TITLE
docs: fix SOPS store type for dotenv files (env -> dotenv)

### DIFF
--- a/docs/spec/v1/kustomizations.md
+++ b/docs/spec/v1/kustomizations.md
@@ -1995,7 +1995,7 @@ the input type when encrypting them with SOPS:
 ```sh
 sops -e --input-type=json config.json > config.json.encrypted
 sops -e --input-type=yaml config.yaml > config.yaml.encrypted
-sops -e --input-type=env config.env > config.env.encrypted
+sops -e --input-type=dotenv --output-type=dotenv config.env > config.env.encrypted
 ```
 
 For kustomize-controller to be able to decrypt a JSON config, you need to set

--- a/docs/spec/v1beta2/kustomizations.md
+++ b/docs/spec/v1beta2/kustomizations.md
@@ -1380,7 +1380,7 @@ For secrets in `.json`, `.yaml` `.ini` and `.env` format, make sure you specify 
 ```sh
 sops -e --input-type=json config.json > config.json.encrypted
 sops -e --input-type=yaml config.yaml > config.yaml.encrypted
-sops -e --input-type=env config.env > config.env.encrypted
+sops -e --input-type=dotenv --output-type=dotenv config.env > config.env.encrypted
 ```
 
 For kustomize-controller to be able to decrypt a JSON config, you need to set the file extension to `.json`:


### PR DESCRIPTION
## Description

The SOPS encryption example in the Kustomization spec docs used:

```console
sops -e --input-type=env config.env > config.env.encrypted
```

SOPS has no `env` store type — its formats are `binary`, `dotenv`, `ini`, `json` and `yaml` (see `getsops/sops` `cmd/sops/formats/formats.go`). An unrecognized `--input-type` silently falls back to `binary`, so this example encrypts the dotenv file as opaque binary rather than as a dotenv file, which then won't decrypt back into key/value pairs as intended.

Fix it to use the `dotenv` store explicitly:

```console
sops -e --input-type=dotenv --output-type=dotenv config.env > config.env.encrypted
```

Applied to both `docs/spec/v1/kustomizations.md` (the canonical source imported by the Flux website) and the `docs/spec/v1beta2/kustomizations.md` copy.
