### PR TITLE
Add categories to the Kustomization CRD

### DIFF
--- a/api/v1/kustomization_types.go
+++ b/api/v1/kustomization_types.go
@@ -449,7 +449,7 @@ func (in *Kustomization) SetConditions(conditions []metav1.Condition) {
 // +genclient
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=ks
+// +kubebuilder:resource:shortName=ks,categories=all;fluxcd;fluxcd-appliers
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""

--- a/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: kustomize.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-appliers
     kind: Kustomization
     listKind: KustomizationList
     plural: kustomizations


### PR DESCRIPTION
This adds the standard Flux resource categories to the Kustomization CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-appliers   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-appliers
```

The CRDs were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
