### PR TITLE
Optimize inventory.Diff with map lookup

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -121,13 +121,9 @@ func ListMetadata(inv *kustomizev1.ResourceInventory) (object.ObjMetadataSet, er
 
 // Diff returns the slice of objects that do not exist in the target inventory.
 func Diff(inv *kustomizev1.ResourceInventory, target *kustomizev1.ResourceInventory) ([]*unstructured.Unstructured, error) {
-	versionOf := func(i *kustomizev1.ResourceInventory, objMetadata object.ObjMetadata) string {
-		for _, entry := range i.Entries {
-			if entry.ID == objMetadata.String() {
-				return entry.Version
-			}
-		}
-		return ""
+	versionMap := make(map[string]string, len(inv.Entries))
+	for _, entry := range inv.Entries {
+		versionMap[entry.ID] = entry.Version
 	}
 
 	objects := make([]*unstructured.Unstructured, 0)
@@ -151,7 +147,7 @@ func Diff(inv *kustomizev1.ResourceInventory, target *kustomizev1.ResourceInvent
 		u.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   metadata.GroupKind.Group,
 			Kind:    metadata.GroupKind.Kind,
-			Version: versionOf(inv, metadata),
+			Version: versionMap[metadata.String()],
 		})
 		u.SetName(metadata.Name)
 		u.SetNamespace(metadata.Namespace)


### PR DESCRIPTION
## What does this change do?

`inventory.Diff` used a `versionOf` closure that performed a linear
scan through all inventory entries on every call — once per item in
the diff list. For an inventory with `n` entries and a diff list of
`m` items, this is O(n*m).

This change builds a version map once upfront (O(n)), then uses O(1)
map lookups per diff item, reducing overall complexity to O(n+m).

On clusters with large inventories this avoids redundant linear scans
on every reconciliation cycle where pruning is needed.

## Testing

Existing `Test_Inventory/diff_objects_in_inventory` passes without
modification — behavior is identical, only the lookup strategy changed.