### PR TITLE
fix: delete stale kustomization-* tmp dirs at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/fluxcd/pkg/testserver v0.14.0
 	github.com/fluxcd/source-controller/api v1.9.0
 	github.com/getsops/sops/v3 v3.13.2
+	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.26.1
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/onsi/gomega v1.42.1
@@ -142,7 +143,6 @@ require (
 	github.com/getsops/gopgagent v0.0.0-20241224165529-7044f28e491e // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect

--- a/main.go
+++ b/main.go
@@ -18,9 +18,12 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -387,8 +390,33 @@ func main() {
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
+	if err := sweepStaleTmpDirs(setupLog); err != nil {
+		setupLog.Error(err, "failed to sweep stale tmp dirs")
+	}
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// sweepStaleTmpDirs removes leftover kustomization-* directories from ungraceful exits.
+// Deferred os.RemoveAll calls in reconcile do not run on SIGKILL or os.Exit(1),
+// so stale dirs can accumulate and consume ephemeral storage (or memory if /tmp is tmpfs).
+func sweepStaleTmpDirs(log logr.Logger) error {
+	dirs, err := ioutil.ReadDir(os.TempDir())
+	if err != nil {
+		return err
+	}
+	for _, d := range dirs {
+		if !d.IsDir() || !filepath.HasPrefix(d.Name(), "kustomization-") {
+			continue
+		}
+		path := filepath.Join(os.TempDir(), d.Name())
+		if err := os.RemoveAll(path); err != nil {
+			log.Error(err, "failed to remove stale tmp dir", "dir", path)
+		} else {
+			log.Info("removed stale tmp dir", "dir", path)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
The kustomize-controller creates a temp dir per reconcile and registers a deferred `os.RemoveAll`. Deferred functions do not run when the process exits ungracefully (SIGKILL, OOMKill, or leader lease lost causing `os.Exit(1)`), and nothing cleans stale dirs on startup. This leaves orphaned `kustomization-*` directories in `/tmp` that accumulate across restarts.

In production, this was observed consuming 1.5GB of orphaned artifacts sitting in a pod's /tmp five days after a crash. When `/tmp` is mounted as `emptyDir: {medium: Memory}`, the leak becomes an OOM loop: the pages stay charged to the pod cgroup, so each OOMKill leaves less headroom for the next start.

This PR adds a `sweepStaleTmpDirs()` function that scans `/tmp` for `kustomization-*` directories and removes them before the manager starts reconciling. It runs on the main goroutine before `mgr.Start()`, so it does not block reconciliation.

Fixes #1723
```release-notes
[BUGFIX] Clean up orphaned kustomization-* temp directories left by ungraceful exits at controller startup.
```