### PR TITLE
fix: purge tmp dirs at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/fluxcd/pkg/testserver v0.14.0
 	github.com/fluxcd/source-controller/api v1.9.0
 	github.com/getsops/sops/v3 v3.13.2
+	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.26.1
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/onsi/gomega v1.42.1
@@ -142,7 +143,6 @@ require (
 	github.com/getsops/gopgagent v0.0.0-20241224165529-7044f28e491e // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect

--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -335,7 +335,7 @@ func (r *KustomizationReconciler) reconcile(
 	}
 
 	// Create tmp dir.
-	tmpDir, err := MkdirTempAbs("", "kustomization-")
+	tmpDir, err := MkdirTempAbs("", TempDirPrefix)
 	if err != nil {
 		err = fmt.Errorf("tmp dir error: %w", err)
 		conditions.MarkFalse(obj, meta.ReadyCondition, sourcev1.DirCreationFailedReason, "%s", err)

--- a/internal/controller/tmpdir.go
+++ b/internal/controller/tmpdir.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+// TempDirPrefix is the name prefix of the temporary directories
+// the reconciler extracts source artifacts into.
+const TempDirPrefix = "kustomization-"
+
+// ListStaleTempDirs returns the absolute paths of the directories in root
+// whose name starts with TempDirPrefix. It must be called before the
+// reconcilers start, so that every match is a leftover of a previous
+// process that exited without running its deferred cleanup.
+func ListStaleTempDirs(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", root, err)
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), TempDirPrefix) {
+			dirs = append(dirs, filepath.Join(root, entry.Name()))
+		}
+	}
+	return dirs, nil
+}
+
+// PurgeTempDirs removes the given directories, logging every removal at
+// info level and every failure at error level. It stops as soon as ctx is
+// done and returns the number of directories that were removed.
+func PurgeTempDirs(ctx context.Context, log logr.Logger, dirs []string) int {
+	purged := 0
+	for i, dir := range dirs {
+		if err := ctx.Err(); err != nil {
+			log.Error(err, "aborted purge of stale tmp dirs",
+				"purged", purged, "remaining", len(dirs)-i)
+			return purged
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			log.Error(err, "failed to remove stale tmp dir", "path", dir)
+			continue
+		}
+		log.Info("removed stale tmp dir", "path", dir)
+		purged++
+	}
+	return purged
+}

--- a/internal/controller/tmpdir_test.go
+++ b/internal/controller/tmpdir_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+)
+
+func TestListStaleTempDirs(t *testing.T) {
+	g := NewWithT(t)
+	root := t.TempDir()
+
+	stale := []string{
+		filepath.Join(root, TempDirPrefix+"1931908412"),
+		filepath.Join(root, TempDirPrefix+"252548195"),
+	}
+	for _, dir := range stale {
+		g.Expect(os.MkdirAll(filepath.Join(dir, "nested"), 0o700)).To(Succeed())
+		g.Expect(os.WriteFile(filepath.Join(dir, "nested", "deployment.yaml"), []byte("kind: Deployment"), 0o600)).To(Succeed())
+	}
+
+	// Entries that must be left alone: a directory with another prefix
+	// and a regular file that happens to carry the prefix.
+	g.Expect(os.Mkdir(filepath.Join(root, "other-123"), 0o700)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(root, TempDirPrefix+"file"), []byte("x"), 0o600)).To(Succeed())
+
+	dirs, err := ListStaleTempDirs(root)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(dirs).To(ConsistOf(stale))
+
+	_, err = ListStaleTempDirs(filepath.Join(root, "missing"))
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestPurgeTempDirs(t *testing.T) {
+	newDirs := func(g *WithT) (string, []string) {
+		root := t.TempDir()
+		dirs := []string{
+			filepath.Join(root, TempDirPrefix+"1931908412"),
+			filepath.Join(root, TempDirPrefix+"252548195"),
+		}
+		for _, dir := range dirs {
+			g.Expect(os.MkdirAll(filepath.Join(dir, "nested"), 0o700)).To(Succeed())
+			g.Expect(os.WriteFile(filepath.Join(dir, "nested", "deployment.yaml"), []byte("kind: Deployment"), 0o600)).To(Succeed())
+		}
+		return root, dirs
+	}
+
+	t.Run("removes listed dirs only", func(t *testing.T) {
+		g := NewWithT(t)
+		root, dirs := newDirs(g)
+		keep := filepath.Join(root, TempDirPrefix+"698526464")
+		g.Expect(os.Mkdir(keep, 0o700)).To(Succeed())
+
+		g.Expect(PurgeTempDirs(context.Background(), logr.Discard(), dirs)).To(Equal(len(dirs)))
+
+		for _, dir := range dirs {
+			g.Expect(dir).NotTo(BeADirectory())
+		}
+		g.Expect(keep).To(BeADirectory())
+	})
+
+	t.Run("tolerates already removed dirs", func(t *testing.T) {
+		g := NewWithT(t)
+		_, dirs := newDirs(g)
+		g.Expect(os.RemoveAll(dirs[0])).To(Succeed())
+
+		g.Expect(PurgeTempDirs(context.Background(), logr.Discard(), dirs)).To(Equal(len(dirs)))
+		for _, dir := range dirs {
+			g.Expect(dir).NotTo(BeADirectory())
+		}
+	})
+
+	t.Run("stops when context is done", func(t *testing.T) {
+		g := NewWithT(t)
+		_, dirs := newDirs(g)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		g.Expect(PurgeTempDirs(ctx, logr.Discard(), dirs)).To(BeZero())
+		for _, dir := range dirs {
+			g.Expect(dir).To(BeADirectory())
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -386,9 +387,35 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
+	purgeStaleTempDirs(ctx)
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// purgeStaleTempDirs removes the tmp dirs left behind by a previous process
+// that exited without running its deferred cleanup. The dirs are listed
+// synchronously, before the reconcilers start creating new ones, and removed
+// in the background so that the manager startup is not delayed.
+func purgeStaleTempDirs(ctx context.Context) {
+	const purgeTimeout = 2 * time.Minute
+
+	dirs, err := controller.ListStaleTempDirs(os.TempDir())
+	if err != nil {
+		setupLog.Error(err, "unable to list stale tmp dirs")
+		return
+	}
+	if len(dirs) == 0 {
+		return
+	}
+
+	setupLog.Info("purging stale tmp dirs", "count", len(dirs))
+	go func() {
+		ctx, cancel := context.WithTimeout(ctx, purgeTimeout)
+		defer cancel()
+		controller.PurgeTempDirs(ctx, setupLog, dirs)
+	}()
 }


### PR DESCRIPTION
This PR makes the controller remove the tmp dirs left behind by a previous process that exited without running its deferred cleanup. The dirs are listed synchronously, before the reconcilers start creating new ones, and removed in the background with a timeout of 2m so that the manager startup is not delayed.

Fixes: #1723
Supersedes: #1726