### PR TITLE
fix: requeue at dependency interval for missing object refs

### DIFF
--- a/internal/controller/kustomization_controller.go
+++ b/internal/controller/kustomization_controller.go
@@ -83,6 +83,11 @@ import (
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
+// errBuildRefNotFound is returned when a Kubernetes object referenced in
+// the build process of a Kustomization, e.g. a substituteFrom ConfigMap or
+// Secret, does not exist.
+var errBuildRefNotFound = errors.New("build reference not found")
+
 // KustomizationReconciler reconciles a Kustomization object
 type KustomizationReconciler struct {
 	client.Client
@@ -215,9 +220,10 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		conditions.MarkFalse(obj, meta.ReadyCondition, meta.ArtifactFailedReason, "%s", err)
 
 		if apierrors.IsNotFound(err) {
-			msg := fmt.Sprintf("Source '%s' not found", obj.Spec.SourceRef.String())
+			msg := fmt.Sprintf("Source '%s' not found, retrying in %s",
+				obj.Spec.SourceRef.String(), r.DependencyRequeueInterval.String())
 			log.Info(msg)
-			return ctrl.Result{RequeueAfter: obj.GetRetryInterval()}, nil
+			return ctrl.Result{RequeueAfter: r.DependencyRequeueInterval}, nil
 		}
 
 		if acl.IsAccessDenied(err) {
@@ -271,6 +277,15 @@ func (r *KustomizationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if errors.Is(reconcileErr, fetch.ErrFileNotFound) {
 		msg := fmt.Sprintf("Source is not ready, artifact not found, retrying in %s", r.DependencyRequeueInterval.String())
 		conditions.MarkFalse(obj, meta.ReadyCondition, meta.ArtifactFailedReason, "%s", msg)
+		log.Info(msg)
+		return ctrl.Result{RequeueAfter: r.DependencyRequeueInterval}, nil
+	}
+
+	// Requeue at the dependency interval if a Kubernetes object referenced
+	// in the build was not found, the object may be created later.
+	if errors.Is(reconcileErr, errBuildRefNotFound) {
+		msg := fmt.Sprintf("Reconciliation failed, retrying in %s: %s",
+			r.DependencyRequeueInterval.String(), reconcileErr.Error())
 		log.Info(msg)
 		return ctrl.Result{RequeueAfter: r.DependencyRequeueInterval}, nil
 	}
@@ -437,6 +452,14 @@ func (r *KustomizationReconciler) reconcile(
 	resources, err := r.build(ctx, obj, unstructured.Unstructured{Object: k}, tmpDir, dirPath)
 	if err != nil {
 		conditions.MarkFalse(obj, meta.ReadyCondition, meta.BuildFailedReason, "%s", err)
+		if apierrors.IsNotFound(err) {
+			// A Kubernetes object referenced in the build, e.g. a
+			// substituteFrom ConfigMap or Secret, does not exist yet.
+			// Exponential backoff would cause the wait for the object
+			// to be prolonged too much, instead we requeue on a fixed
+			// interval by tagging the error with errBuildRefNotFound.
+			return fmt.Errorf("%w: %w", errBuildRefNotFound, err)
+		}
 		return err
 	}
 

--- a/internal/controller/kustomization_requeue_dependency_test.go
+++ b/internal/controller/kustomization_requeue_dependency_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fluxcd/pkg/testserver"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+)
+
+func TestKustomizationReconciler_RequeueOnMissingRefs(t *testing.T) {
+	g := NewWithT(t)
+	id := "missing-refs-" + randStringRunes(5)
+	revision := "v1.0.0/" + randStringRunes(7)
+
+	err := createNamespace(id)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+	t.Run("requeues at dependency interval when source is not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		kustomization := &kustomizev1.Kustomization{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-source-" + randStringRunes(5),
+				Namespace: id,
+			},
+			Spec: kustomizev1.KustomizationSpec{
+				Interval: metav1.Duration{Duration: 10 * time.Minute},
+				Path:     "./",
+				Prune:    true,
+				SourceRef: kustomizev1.CrossNamespaceSourceReference{
+					Name:      "does-not-exist",
+					Namespace: id,
+					Kind:      sourcev1.GitRepositoryKind,
+				},
+			},
+		}
+		g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
+
+		g.Eventually(func(g Gomega) {
+			res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(kustomization),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res.RequeueAfter).To(Equal(reconciler.DependencyRequeueInterval))
+		}, timeout, time.Second).Should(Succeed())
+	})
+
+	t.Run("requeues at dependency interval when substituteFrom is not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		manifests := []testserver.File{
+			{
+				Name: "configmap.yaml",
+				Body: fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s
+data:
+  key: value
+`, id),
+			},
+		}
+		artifact, err := testServer.ArtifactFromFiles(manifests)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		repositoryName := types.NamespacedName{
+			Name:      randStringRunes(5),
+			Namespace: id,
+		}
+		err = applyGitRepository(repositoryName, artifact, revision)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		kustomization := &kustomizev1.Kustomization{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-substitute-" + randStringRunes(5),
+				Namespace: id,
+			},
+			Spec: kustomizev1.KustomizationSpec{
+				Interval: metav1.Duration{Duration: 10 * time.Minute},
+				Path:     "./",
+				Prune:    true,
+				SourceRef: kustomizev1.CrossNamespaceSourceReference{
+					Name:      repositoryName.Name,
+					Namespace: repositoryName.Namespace,
+					Kind:      sourcev1.GitRepositoryKind,
+				},
+				PostBuild: &kustomizev1.PostBuild{
+					SubstituteFrom: []kustomizev1.SubstituteReference{
+						{
+							Kind: "ConfigMap",
+							Name: "does-not-exist",
+						},
+					},
+				},
+				TargetNamespace: id,
+			},
+		}
+		g.Expect(k8sClient.Create(context.Background(), kustomization)).To(Succeed())
+
+		g.Eventually(func(g Gomega) {
+			res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(kustomization),
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res.RequeueAfter).To(Equal(reconciler.DependencyRequeueInterval))
+		}, timeout, time.Second).Should(Succeed())
+	})
+}


### PR DESCRIPTION
Part of fluxcd/flux2#5809

When the referenced Source object does not exist, the controller requeued at the retry interval; when a non-optional `substituteFrom` ConfigMap/Secret does not exist, the failure fell into the generic reconcile-error path, also requeueing at the retry interval. Both are inconsistent with how not ready dependencies, nil source artifacts and missing artifact files are handled, all of which requeue at the `--requeue-dependency` interval, and they delay bootstrap ordering when the referenced objects are created shortly after the Kustomization (e.g. via a ResourceSet).

This change:

- requeues at `--requeue-dependency` when the source object is not found;
- tags build errors caused by a missing referenced Kubernetes object (e.g. `substituteFrom` ConfigMap/Secret) with a sentinel `errBuildRefNotFound` and requeues them at `--requeue-dependency`, alongside the existing `fetch.ErrFileNotFound` handling. The Ready=False condition with `BuildFailedReason` and the full error message is still recorded.

The check is deliberately scoped to the build step rather than a blanket `apierrors.IsNotFound(reconcileErr)`: `fluxcd/pkg/ssa` wraps apply errors with `%w`, so a blanket check would also reroute apply-time NotFound failures (e.g. a namespace that does not exist) away from their error events.

Tests: new `TestKustomizationReconciler_RequeueOnMissingRefs` asserts the returned `RequeueAfter` equals the dependency interval for both scenarios; both subtests were verified to fail against the unfixed code (they observed the 10m retry interval).

Signed-off-by: Bisman-Singh <bismanmadaan1@gmail.com>